### PR TITLE
set imageurl prefix to use new nextcloud-commons capabilities

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -126,6 +126,7 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
         super.onNoteLoaded(note);
         noteLoaded = true;
         registerInternalNoteLinkHandler();
+        binding.singleNoteContent.setMarkdownImageUrlPrefix(repo.getAccountById(note.getAccountId()).getUrl()+"/index.php/apps/notes/notes/"+note.getRemoteId()+"/attachment?path=");
         changedText = note.getContent();
         binding.singleNoteContent.setMarkdownString(note.getContent(), setScrollY);
         binding.singleNoteContent.getMarkdownString().observe(requireActivity(), (newContent) -> {


### PR DESCRIPTION
This sets the url prefix in nextcloud-commons:markdown


It requires [newhinton:feature/noid/imageurl](https://github.com/newhinton/nextcloud-commons/tree/feature/noid/imageurl), until a version with this pr is released, it is nessessary to add a local version of that branch to be used by the notes app.


This pr is tiny, and only supports images. The web-app does support arbitrary attachments, and provides a download for those. However, i think i broke mardown-conventions in doing so, so we may or may not want to support it here aswell. If we do want to support it, i have to change the library to make it work.


Also, when images cannot be loaded, we currently only show a broken image, shouldnt we also display the alt-text?


closes #1051 

Oh, and i didnt check if servers that override index.php work, since the note object did not provide the "basepath", just the fqdn (or ip adress in my case)