### PR TITLE
CI: Don't run on push except on main and stable branches

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,9 @@
 name: Android CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ main, stable-* ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Right now, when opening a PR the CI is ran twice (one for the push event and one for the PR event).

This prevents that: PRs will only get the CI ran once
