### PR TITLE
feat(theming): Use nextcloud-common library for theming UI elements (#1648)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.2'
 
     // Nextcloud SSO
+    implementation 'com.github.nextcloud:android-common:0.4.0'
     implementation 'com.github.nextcloud:Android-SingleSignOn:0.6.1'
     implementation 'com.github.stefan-niedermann:android-commons:0.2.9'
     implementation 'com.github.stefan-niedermann.nextcloud-commons:sso-glide:1.6.4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.2'
 
     // Nextcloud SSO
-    implementation 'com.github.nextcloud:android-common:0.4.0'
+    implementation 'com.github.nextcloud.android-common:ui:0.6.0'
     implementation 'com.github.nextcloud:Android-SingleSignOn:0.6.1'
     implementation 'com.github.stefan-niedermann:android-commons:0.2.9'
     implementation 'com.github.stefan-niedermann.nextcloud-commons:sso-glide:1.6.4'

--- a/app/src/main/java/it/niedermann/owncloud/notes/FormattingHelpActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/FormattingHelpActivity.java
@@ -223,8 +223,8 @@ public class FormattingHelpActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/FormattingHelpActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/FormattingHelpActivity.java
@@ -12,6 +12,7 @@ import androidx.preference.PreferenceManager;
 
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandedActivity;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ActivityFormattingHelpBinding;
 
 import static it.niedermann.owncloud.notes.shared.util.NoteUtil.getFontSizeFromPreferences;
@@ -223,6 +224,7 @@ public class FormattingHelpActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
@@ -1,19 +1,15 @@
 package it.niedermann.owncloud.notes;
 
+import static androidx.preference.PreferenceManager.getDefaultSharedPreferences;
+
 import android.app.Application;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import android.util.Log;
 
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
 
 import it.niedermann.owncloud.notes.preferences.DarkModeSetting;
-
-import static androidx.preference.PreferenceManager.getDefaultSharedPreferences;
-
-import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 
 public class NotesApplication extends Application {
     private static final String TAG = NotesApplication.class.getSimpleName();
@@ -57,18 +53,6 @@ public class NotesApplication extends Application {
             mode = darkModeEnabled ? DarkModeSetting.DARK.name() : DarkModeSetting.LIGHT.name();
         }
         return DarkModeSetting.valueOf(mode);
-    }
-
-    public static boolean isDarkThemeActive(Context context, DarkModeSetting setting) {
-        if (setting == DarkModeSetting.SYSTEM_DEFAULT) {
-            return isDarkThemeActive(context);
-        } else {
-            return setting == DarkModeSetting.DARK;
-        }
-    }
-
-    public static boolean isDarkThemeActive(Context context) {
-        return PlatformThemeUtil.isDarkMode(context);
     }
 
     public static void setLockedPreference(boolean lockedPreference) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
@@ -13,6 +13,8 @@ import it.niedermann.owncloud.notes.preferences.DarkModeSetting;
 
 import static androidx.preference.PreferenceManager.getDefaultSharedPreferences;
 
+import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
+
 public class NotesApplication extends Application {
     private static final String TAG = NotesApplication.class.getSimpleName();
 
@@ -66,8 +68,7 @@ public class NotesApplication extends Application {
     }
 
     public static boolean isDarkThemeActive(Context context) {
-        final int uiMode = context.getResources().getConfiguration().uiMode;
-        return (uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        return PlatformThemeUtil.isDarkMode(context);
     }
 
     public static void setLockedPreference(boolean lockedPreference) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/about/AboutActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/about/AboutActivity.java
@@ -51,9 +51,9 @@ public class AboutActivity extends LockedActivity {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar);
-        @ColorInt int finalMainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(this, mainColor);
-        binding.tabs.setSelectedTabIndicatorColor(finalMainColor);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.material.themeTabLayout(binding.tabs);
+        util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 
     private static class TabsStateAdapter extends FragmentStateAdapter {

--- a/app/src/main/java/it/niedermann/owncloud/notes/about/AboutActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/about/AboutActivity.java
@@ -50,8 +50,8 @@ public class AboutActivity extends LockedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.material.themeTabLayout(binding.tabs);
         util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/about/AboutFragmentLicenseTab.java
@@ -35,8 +35,7 @@ public class AboutFragmentLicenseTab extends BrandedFragment {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        @ColorInt final int finalMainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
-        DrawableCompat.setTintList(binding.aboutAppLicenseButton.getBackground(), ColorStateList.valueOf(finalMainColor));
-        binding.aboutAppLicenseButton.setTextColor(ColorUtil.INSTANCE.getForegroundColorForBackgroundColor(finalMainColor));
+        final var util = BrandingUtil.of(mainColor, requireContext());
+        util.material.colorMaterialButtonPrimaryFilled(binding.aboutAppLicenseButton);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/about/AboutFragmentLicenseTab.java
@@ -34,8 +34,8 @@ public class AboutFragmentLicenseTab extends BrandedFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, requireContext());
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, requireContext());
         util.material.colorMaterialButtonPrimaryFilled(binding.aboutAppLicenseButton);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/accountpicker/AccountPickerDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/accountpicker/AccountPickerDialogFragment.java
@@ -109,7 +109,7 @@ public class AccountPickerDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int color) {
         // Nothing to do...
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/accountswitcher/AccountSwitcherDialog.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/accountswitcher/AccountSwitcherDialog.java
@@ -116,8 +116,8 @@ public class AccountSwitcherDialog extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, requireContext());
-        util.notes.colorLayerDrawable((LayerDrawable) binding.check.getDrawable(), R.id.area, mainColor);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, requireContext());
+        util.notes.colorLayerDrawable((LayerDrawable) binding.check.getDrawable(), R.id.area, color);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/accountswitcher/AccountSwitcherDialog.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/accountswitcher/AccountSwitcherDialog.java
@@ -1,7 +1,5 @@
 package it.niedermann.owncloud.notes.accountswitcher;
 
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.applyBrandToLayerDrawable;
-
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -18,6 +16,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandedDialogFragment;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.DialogAccountSwitcherBinding;
 import it.niedermann.owncloud.notes.manageaccounts.ManageAccountsActivity;
 import it.niedermann.owncloud.notes.persistence.NotesRepository;
@@ -118,6 +117,7 @@ public class AccountSwitcherDialog extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToLayerDrawable((LayerDrawable) binding.check.getDrawable(), R.id.area, mainColor);
+        final var util = BrandingUtil.of(mainColor, requireContext());
+        util.notes.colorLayerDrawable((LayerDrawable) binding.check.getDrawable(), R.id.area, mainColor);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/Branded.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/Branded.java
@@ -5,5 +5,5 @@ import androidx.annotation.UiThread;
 
 public interface Branded {
     @UiThread
-    void applyBrand(@ColorInt int mainColor, @ColorInt int textColor);
+    void applyBrand(@ColorInt int color);
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedActivity.java
@@ -1,6 +1,6 @@
 package it.niedermann.owncloud.notes.branding;
 
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandColors;
+import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandMainColorLiveData;
 
 import android.util.TypedValue;
 import android.view.Menu;
@@ -23,7 +23,7 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
         getTheme().resolveAttribute(R.attr.colorAccent, typedValue, true);
         colorAccent = typedValue.data;
 
-        readBrandColors(this).observe(this, (pair) -> applyBrand(pair.first, pair.second));
+        readBrandMainColorLiveData(this).observe(this, this::applyBrand);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedActivity.java
@@ -1,34 +1,19 @@
 package it.niedermann.owncloud.notes.branding;
 
-import android.content.res.ColorStateList;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
+import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandColors;
+
 import android.util.TypedValue;
 import android.view.Menu;
 
 import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
-
-import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import it.niedermann.owncloud.notes.R;
-
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandColors;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.tintMenuIcon;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
 
     @ColorInt
     protected int colorAccent;
-
-    public static void applyBrandToFAB(@ColorInt int mainColor, @ColorInt int textColor, @NonNull FloatingActionButton fab) {
-        fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
-        fab.setColorFilter(textColor);
-    }
 
     @Override
     protected void onStart() {
@@ -43,26 +28,12 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
+        final var utils = BrandingUtil.of(colorAccent, this);
+
         for (int i = 0; i < menu.size(); i++) {
-            tintMenuIcon(menu.getItem(i), colorAccent);
+            utils.platform.colorToolbarMenuIcon(this, menu.getItem(i));
         }
+
         return super.onCreateOptionsMenu(menu);
-    }
-
-    public void applyBrandToPrimaryToolbar(@NonNull AppBarLayout appBarLayout, @NonNull Toolbar toolbar) {
-        // FIXME Workaround for https://github.com/nextcloud/notes-android/issues/889
-        appBarLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.primary));
-
-        final var overflowDrawable = toolbar.getOverflowIcon();
-        if (overflowDrawable != null) {
-            overflowDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-            toolbar.setOverflowIcon(overflowDrawable);
-        }
-
-        final var navigationDrawable = toolbar.getNavigationIcon();
-        if (navigationDrawable != null) {
-            navigationDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-            toolbar.setNavigationIcon(navigationDrawable);
-        }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedDialogFragment.java
@@ -13,8 +13,7 @@ public abstract class BrandedDialogFragment extends DialogFragment implements Br
         super.onStart();
 
         @Nullable final var context = requireContext();
-        @ColorInt final int mainColor = BrandingUtil.readBrandMainColor(context);
-        @ColorInt final int textColor = BrandingUtil.readBrandTextColor(context);
-        applyBrand(mainColor, textColor);
+        @ColorInt final int color = BrandingUtil.readBrandMainColor(context);
+        applyBrand(color);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedFragment.java
@@ -28,9 +28,8 @@ public abstract class BrandedFragment extends Fragment implements Branded {
         context.getTheme().resolveAttribute(R.attr.colorPrimary, typedValue, true);
         colorPrimary = typedValue.data;
 
-        @ColorInt final int mainColor = BrandingUtil.readBrandMainColor(context);
-        @ColorInt final int textColor = BrandingUtil.readBrandTextColor(context);
-        applyBrand(mainColor, textColor);
+        @ColorInt final int color = BrandingUtil.readBrandMainColor(context);
+        applyBrand(color);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedFragment.java
@@ -1,18 +1,14 @@
 package it.niedermann.owncloud.notes.branding;
 
-import android.content.Context;
 import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuInflater;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import it.niedermann.owncloud.notes.R;
-
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.tintMenuIcon;
 
 public abstract class BrandedFragment extends Fragment implements Branded {
 
@@ -40,8 +36,12 @@ public abstract class BrandedFragment extends Fragment implements Branded {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
+        final var utils = BrandingUtil.of(colorAccent, requireContext());
+
         for (int i = 0; i < menu.size(); i++) {
-            tintMenuIcon(menu.getItem(i), colorAccent);
+            if (menu.getItem(i).getIcon() != null) {
+                utils.platform.colorToolbarMenuIcon(requireContext(), menu.getItem(i));
+            }
         }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedPreferenceCategory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedPreferenceCategory.java
@@ -8,6 +8,8 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceViewHolder;
 
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
+
 public class BrandedPreferenceCategory extends PreferenceCategory {
 
     public BrandedPreferenceCategory(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -33,8 +35,9 @@ public class BrandedPreferenceCategory extends PreferenceCategory {
         final var view = holder.itemView.findViewById(android.R.id.title);
         @Nullable final var context = getContext();
         if (view instanceof TextView) {
-            final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);;
-            ((TextView) view).setTextColor(util.notes.getOnPrimaryContainer(context));
+            final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);
+
+            util.platform.colorTextView((TextView) view, ColorRole.ON_PRIMARY_CONTAINER);
         }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedPreferenceCategory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedPreferenceCategory.java
@@ -2,15 +2,11 @@ package it.niedermann.owncloud.notes.branding;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.View;
 import android.widget.TextView;
 
-import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceViewHolder;
-
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class BrandedPreferenceCategory extends PreferenceCategory {
 
@@ -36,9 +32,9 @@ public class BrandedPreferenceCategory extends PreferenceCategory {
 
         final var view = holder.itemView.findViewById(android.R.id.title);
         @Nullable final var context = getContext();
-        if (context != null && view instanceof TextView) {
-            @ColorInt final int mainColor = getSecondaryForegroundColorDependingOnTheme(context, BrandingUtil.readBrandMainColor(context));
-            ((TextView) view).setTextColor(mainColor);
+        if (view instanceof TextView) {
+            final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);;
+            ((TextView) view).setTextColor(util.notes.getOnPrimaryContainer(context));
         }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSnackbar.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSnackbar.java
@@ -1,11 +1,7 @@
 package it.niedermann.owncloud.notes.branding;
 
-import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getAttribute;
 import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandMainColor;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
 
-import android.graphics.Color;
 import android.view.View;
 
 import androidx.annotation.ColorInt;
@@ -15,26 +11,15 @@ import androidx.annotation.StringRes;
 import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
 
-import it.niedermann.owncloud.notes.R;
-
 public class BrandedSnackbar {
 
     @NonNull
     public static Snackbar make(@NonNull View view, @NonNull CharSequence text, @BaseTransientBottomBar.Duration int duration) {
-        final var snackbar = Snackbar.make(view, text, duration);
-
-        @ColorInt final int backgroundColor = getAttribute(view.getContext(), R.attr.colorSurfaceInverse);
         @ColorInt final int color = readBrandMainColor(view.getContext());
+        final var snackbar = Snackbar.make(view, text, duration);
+        final var utils = BrandingUtil.of(color, view.getContext());
 
-        if (contrastRatioIsSufficient(backgroundColor, color)) {
-            snackbar.setActionTextColor(color);
-        } else {
-            if (isDarkThemeActive(view.getContext())) {
-                snackbar.setActionTextColor(Color.BLACK);
-            } else {
-                snackbar.setActionTextColor(Color.WHITE);
-            }
-        }
+        utils.material.themeSnackbar(snackbar);
 
         return snackbar;
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSwitchPreference.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSwitchPreference.java
@@ -17,9 +17,6 @@ public class BrandedSwitchPreference extends SwitchPreference implements Branded
     @ColorInt
     private Integer mainColor = null;
 
-    @ColorInt
-    private Integer textColor = null;
-
     @SuppressLint("UseSwitchCompatOrMaterialCode")
     @Nullable
     private Switch switchView;
@@ -46,16 +43,15 @@ public class BrandedSwitchPreference extends SwitchPreference implements Branded
 
         if (holder.itemView instanceof ViewGroup) {
             switchView = findSwitchWidget(holder.itemView);
-            if (mainColor != null && textColor != null) {
+            if (mainColor != null) {
                 applyBrand();
             }
         }
     }
 
     @Override
-    public void applyBrand(@ColorInt int mainColor, @ColorInt int textColor) {
-        this.mainColor = mainColor;
-        this.textColor = textColor;
+    public void applyBrand(@ColorInt int color) {
+        this.mainColor = color;
         // onBindViewHolder is called after applyBrand, therefore we have to store the given values and apply them later.
         applyBrand();
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSwitchPreference.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandedSwitchPreference.java
@@ -2,8 +2,6 @@ package it.niedermann.owncloud.notes.branding;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,13 +9,8 @@ import android.widget.Switch;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.preference.PreferenceViewHolder;
 import androidx.preference.SwitchPreference;
-
-import it.niedermann.owncloud.notes.R;
-
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class BrandedSwitchPreference extends SwitchPreference implements Branded {
 
@@ -69,16 +62,8 @@ public class BrandedSwitchPreference extends SwitchPreference implements Branded
 
     private void applyBrand() {
         if (switchView != null) {
-            final int finalMainColor = getSecondaryForegroundColorDependingOnTheme(getContext(), mainColor);
-            // int trackColor = Color.argb(77, Color.red(finalMainColor), Color.green(finalMainColor), Color.blue(finalMainColor));
-            DrawableCompat.setTintList(switchView.getThumbDrawable(), new ColorStateList(
-                    new int[][]{new int[]{android.R.attr.state_checked}, new int[]{}},
-                    new int[]{finalMainColor, getContext().getResources().getColor(R.color.fg_default_low)}
-            ));
-            DrawableCompat.setTintList(switchView.getTrackDrawable(), new ColorStateList(
-                    new int[][]{new int[]{android.R.attr.state_checked}, new int[]{}},
-                    new int[]{finalMainColor, getContext().getResources().getColor(R.color.fg_default_low)}
-            ));
+            final var util = BrandingUtil.of(mainColor, getContext());
+            util.platform.colorSwitch(switchView);
         }
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.LiveData;
 import androidx.preference.PreferenceManager;
 
@@ -57,14 +58,14 @@ public class BrandingUtil extends ViewThemeUtilsBase {
     public static LiveData<Integer> readBrandMainColorLiveData(@NonNull Context context) {
         final var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         Log.v(TAG, "--- Read: shared_preference_theme_main");
-        return new SharedPreferenceIntLiveData(sharedPreferences, pref_key_branding_main, context.getApplicationContext().getResources().getColor(R.color.defaultBrand));
+        return new SharedPreferenceIntLiveData(sharedPreferences, pref_key_branding_main, ContextCompat.getColor(context, R.color.defaultBrand));
     }
 
     @ColorInt
     public static int readBrandMainColor(@NonNull Context context) {
         final var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         Log.v(TAG, "--- Read: shared_preference_theme_main");
-        return sharedPreferences.getInt(pref_key_branding_main, context.getApplicationContext().getResources().getColor(R.color.defaultBrand));
+        return sharedPreferences.getInt(pref_key_branding_main, ContextCompat.getColor(context, R.color.defaultBrand));
     }
 
     public static void saveBrandColor(@NonNull Context context, @ColorInt int color) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
@@ -1,56 +1,32 @@
 package it.niedermann.owncloud.notes.branding;
 
-import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficientBigAreas;
-
 import android.content.Context;
-import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.graphics.drawable.LayerDrawable;
 import android.util.Log;
-import android.util.TypedValue;
-import android.view.MenuItem;
-import android.widget.EditText;
-import android.widget.TextView;
 
-import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
-import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.core.util.Pair;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.textfield.TextInputLayout;
 import com.nextcloud.android.common.ui.theme.MaterialSchemes;
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
 import com.nextcloud.android.common.ui.theme.utils.AndroidViewThemeUtils;
 import com.nextcloud.android.common.ui.theme.utils.AndroidXViewThemeUtils;
 import com.nextcloud.android.common.ui.theme.utils.DialogViewThemeUtils;
 import com.nextcloud.android.common.ui.theme.utils.MaterialViewThemeUtils;
-import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import it.niedermann.android.sharedpreferences.SharedPreferenceIntLiveData;
-import it.niedermann.android.util.ColorUtil;
-import it.niedermann.owncloud.notes.NotesApplication;
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.shared.util.NotesColorUtil;
-import scheme.Scheme;
 
 public class BrandingUtil extends ViewThemeUtilsBase {
 
     private static final String TAG = BrandingUtil.class.getSimpleName();
     private static final ConcurrentMap<Integer, BrandingUtil> CACHE = new ConcurrentHashMap<>();
     private static final String pref_key_branding_main = "branding_main";
-    private static final String pref_key_branding_text = "branding_text";
 
     public final AndroidViewThemeUtils platform;
     public final MaterialViewThemeUtils material;
@@ -78,42 +54,10 @@ public class BrandingUtil extends ViewThemeUtilsBase {
         ));
     }
 
-    public static LiveData<Pair<Integer, Integer>> readBrandColors(@NonNull Context context) {
-        return new BrandingLiveData(context);
-    }
-
-    private static class BrandingLiveData extends MediatorLiveData<Pair<Integer, Integer>> {
-        @ColorInt
-        Integer lastMainColor = null;
-        @ColorInt
-        Integer lastTextColor = null;
-
-        public BrandingLiveData(@NonNull Context context) {
-            addSource(readBrandMainColorLiveData(context), (nextMainColor) -> {
-                lastMainColor = nextMainColor;
-                if (lastTextColor != null) {
-                    postValue(new Pair<>(lastMainColor, lastTextColor));
-                }
-            });
-            addSource(readBrandTextColorLiveData(context), (nextTextColor) -> {
-                lastTextColor = nextTextColor;
-                if (lastMainColor != null) {
-                    postValue(new Pair<>(lastMainColor, lastTextColor));
-                }
-            });
-        }
-    }
-
     public static LiveData<Integer> readBrandMainColorLiveData(@NonNull Context context) {
         final var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         Log.v(TAG, "--- Read: shared_preference_theme_main");
         return new SharedPreferenceIntLiveData(sharedPreferences, pref_key_branding_main, context.getApplicationContext().getResources().getColor(R.color.defaultBrand));
-    }
-
-    public static LiveData<Integer> readBrandTextColorLiveData(@NonNull Context context) {
-        final var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-        Log.v(TAG, "--- Read: shared_preference_theme_text");
-        return new SharedPreferenceIntLiveData(sharedPreferences, pref_key_branding_text, Color.WHITE);
     }
 
     @ColorInt
@@ -123,24 +67,14 @@ public class BrandingUtil extends ViewThemeUtilsBase {
         return sharedPreferences.getInt(pref_key_branding_main, context.getApplicationContext().getResources().getColor(R.color.defaultBrand));
     }
 
-    @ColorInt
-    public static int readBrandTextColor(@NonNull Context context) {
-        final var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-        Log.v(TAG, "--- Read: shared_preference_theme_text");
-        return sharedPreferences.getInt(pref_key_branding_text, Color.WHITE);
-    }
-
-    public static void saveBrandColors(@NonNull Context context, @ColorInt int mainColor, @ColorInt int textColor) {
+    public static void saveBrandColor(@NonNull Context context, @ColorInt int color) {
         final int previousMainColor = readBrandMainColor(context);
-        final int previousTextColor = readBrandTextColor(context);
         final var editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
-        Log.v(TAG, "--- Write: shared_preference_theme_main" + " | " + mainColor);
-        Log.v(TAG, "--- Write: shared_preference_theme_text" + " | " + textColor);
-        editor.putInt(pref_key_branding_main, mainColor);
-        editor.putInt(pref_key_branding_text, textColor);
+        Log.v(TAG, "--- Write: shared_preference_theme_main" + " | " + color);
+        editor.putInt(pref_key_branding_main, color);
         editor.apply();
         if (context instanceof BrandedActivity) {
-            if (mainColor != previousMainColor || textColor != previousTextColor) {
+            if (color != previousMainColor) {
                 final var activity = (BrandedActivity) context;
                 activity.runOnUiThread(() -> ActivityCompat.recreate(activity));
             }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -1,7 +1,7 @@
 package it.niedermann.owncloud.notes.branding;
 
 import static com.nextcloud.android.common.ui.util.ColorStateListUtilsKt.buildColorStateList;
-import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
+import static com.nextcloud.android.common.ui.util.PlatformThemeUtil.isDarkMode;
 
 import android.content.Context;
 import android.graphics.Color;
@@ -21,7 +21,6 @@ import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.navigation.NavigationView;
 import com.nextcloud.android.common.ui.theme.MaterialSchemes;
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
 import com.nextcloud.android.common.ui.theme.utils.MaterialViewThemeUtils;
@@ -125,7 +124,7 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
 
     @ColorInt
     public int getTextHighlightBackgroundColor(@NonNull Context context, @ColorInt int mainColor, @ColorInt int colorPrimary, @ColorInt int colorAccent) {
-        if (isDarkThemeActive(context)) { // Dark background
+        if (isDarkMode(context)) { // Dark background
             if (ColorUtil.INSTANCE.isColorDark(mainColor)) { // Dark brand color
                 if (NotesColorUtil.contrastRatioIsSufficient(mainColor, colorPrimary)) { // But also dark text
                     return mainColor;

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -42,15 +42,6 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
     }
 
     /**
-     * Use {@link ColorRole#ON_PRIMARY_CONTAINER}
-     */
-    @Deprecated(forRemoval = true)
-    @ColorInt
-    public int getOnPrimaryContainer(@NonNull Context context) {
-        return withScheme(context, Scheme::getOnPrimaryContainer);
-    }
-
-    /**
      * The Notes app uses custom navigation view items because they have several features which are
      * not covered by {@link NavigationItem}.
      */

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -1,5 +1,6 @@
 package it.niedermann.owncloud.notes.branding;
 
+import static com.nextcloud.android.common.ui.util.ColorStateListUtilsKt.buildColorStateList;
 import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
 
 import android.content.Context;
@@ -7,6 +8,9 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.LayerDrawable;
 import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.IdRes;
@@ -16,20 +20,27 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.navigation.NavigationView;
 import com.nextcloud.android.common.ui.theme.MaterialSchemes;
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
+import com.nextcloud.android.common.ui.theme.utils.MaterialViewThemeUtils;
 
 import it.niedermann.android.util.ColorUtil;
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.main.navigation.NavigationItem;
 import it.niedermann.owncloud.notes.shared.util.NotesColorUtil;
+import kotlin.Pair;
 import scheme.Scheme;
 
 public class NotesViewThemeUtils extends ViewThemeUtilsBase {
 
     private static final String TAG = NotesViewThemeUtils.class.getSimpleName();
+    private final MaterialSchemes schemes;
 
     public NotesViewThemeUtils(@NonNull MaterialSchemes schemes) {
         super(schemes);
+        this.schemes = schemes;
     }
 
     @ColorInt
@@ -37,6 +48,51 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
         return withScheme(context, Scheme::getOnPrimaryContainer);
     }
 
+    /**
+     * The Notes app uses custom navigation view items because they have several features which are
+     * not covered by {@link NavigationItem}.
+     */
+    public void colorNavigationViewItem(@NonNull View view) {
+        withScheme(view, scheme -> {
+            view.setBackgroundTintList(buildColorStateList(
+                    new Pair<>(android.R.attr.state_selected, scheme.getSecondaryContainer()),
+                    new Pair<>(-android.R.attr.state_selected, Color.TRANSPARENT)
+            ));
+            return view;
+        });
+    }
+
+    /**
+     * The Notes app uses custom navigation view items because they have several features which are
+     * not covered by {@link NavigationItem}.
+     */
+    public void colorNavigationViewItemIcon(@NonNull ImageView view) {
+        withScheme(view, scheme -> {
+            view.setImageTintList(buildColorStateList(
+                    new Pair<>(android.R.attr.state_selected, scheme.getOnSecondaryContainer()),
+                    new Pair<>(-android.R.attr.state_selected, scheme.getOnSurfaceVariant())
+            ));
+            return view;
+        });
+    }
+
+    /**
+     * The Notes app uses custom navigation view items because they have several features which are
+     * not covered by {@link NavigationItem}.
+     */
+    public void colorNavigationViewItemText(@NonNull TextView view) {
+        withScheme(view, scheme -> {
+            view.setTextColor(buildColorStateList(
+                    new Pair<>(android.R.attr.state_selected, scheme.getOnSecondaryContainer()),
+                    new Pair<>(-android.R.attr.state_selected, scheme.getOnSurfaceVariant())
+            ));
+            return view;
+        });
+    }
+
+    /**
+     * @deprecated should be replaced by {@link MaterialViewThemeUtils#themeToolbar(MaterialToolbar)}.
+     */
     @Deprecated(forRemoval = true)
     public void applyBrandToPrimaryToolbar(@NonNull AppBarLayout appBarLayout, @NonNull Toolbar toolbar, @ColorInt int color) {
         // FIXME Workaround for https://github.com/nextcloud/notes-android/issues/889
@@ -55,7 +111,9 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
         }
     }
 
-    @Deprecated(forRemoval = true)
+    /**
+     * Colorizes only a specific part of a drawable
+     */
     public void colorLayerDrawable(@NonNull LayerDrawable check, @IdRes int areaToColor, @ColorInt int mainColor) {
         final var drawable = check.findDrawableByLayerId(areaToColor);
         if (drawable == null) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -23,6 +23,7 @@ import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.nextcloud.android.common.ui.theme.MaterialSchemes;
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.android.common.ui.theme.utils.MaterialViewThemeUtils;
 
 import it.niedermann.android.util.ColorUtil;
@@ -35,13 +36,15 @@ import scheme.Scheme;
 public class NotesViewThemeUtils extends ViewThemeUtilsBase {
 
     private static final String TAG = NotesViewThemeUtils.class.getSimpleName();
-    private final MaterialSchemes schemes;
 
     public NotesViewThemeUtils(@NonNull MaterialSchemes schemes) {
         super(schemes);
-        this.schemes = schemes;
     }
 
+    /**
+     * Use {@link ColorRole#ON_PRIMARY_CONTAINER}
+     */
+    @Deprecated(forRemoval = true)
     @ColorInt
     public int getOnPrimaryContainer(@NonNull Context context) {
         return withScheme(context, Scheme::getOnPrimaryContainer);

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -1,0 +1,100 @@
+package it.niedermann.owncloud.notes.branding;
+
+import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.LayerDrawable;
+import android.util.Log;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+
+import com.google.android.material.appbar.AppBarLayout;
+import com.nextcloud.android.common.ui.theme.MaterialSchemes;
+import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
+
+import it.niedermann.android.util.ColorUtil;
+import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.shared.util.NotesColorUtil;
+import scheme.Scheme;
+
+public class NotesViewThemeUtils extends ViewThemeUtilsBase {
+
+    private static final String TAG = NotesViewThemeUtils.class.getSimpleName();
+
+    public NotesViewThemeUtils(@NonNull MaterialSchemes schemes) {
+        super(schemes);
+    }
+
+    @ColorInt
+    public int getOnPrimaryContainer(@NonNull Context context) {
+        return withScheme(context, Scheme::getOnPrimaryContainer);
+    }
+
+    @Deprecated(forRemoval = true)
+    public void applyBrandToPrimaryToolbar(@NonNull AppBarLayout appBarLayout, @NonNull Toolbar toolbar, @ColorInt int color) {
+        // FIXME Workaround for https://github.com/nextcloud/notes-android/issues/889
+        appBarLayout.setBackgroundColor(ContextCompat.getColor(appBarLayout.getContext(), R.color.primary));
+
+        final var overflowDrawable = toolbar.getOverflowIcon();
+        if (overflowDrawable != null) {
+            overflowDrawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            toolbar.setOverflowIcon(overflowDrawable);
+        }
+
+        final var navigationDrawable = toolbar.getNavigationIcon();
+        if (navigationDrawable != null) {
+            navigationDrawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            toolbar.setNavigationIcon(navigationDrawable);
+        }
+    }
+
+    @Deprecated(forRemoval = true)
+    public void colorLayerDrawable(@NonNull LayerDrawable check, @IdRes int areaToColor, @ColorInt int mainColor) {
+        final var drawable = check.findDrawableByLayerId(areaToColor);
+        if (drawable == null) {
+            Log.e(TAG, "Could not find areaToColor (" + areaToColor + "). Cannot apply brand.");
+        } else {
+            DrawableCompat.setTint(drawable, mainColor);
+        }
+    }
+
+    @ColorInt
+    public int getTextHighlightBackgroundColor(@NonNull Context context, @ColorInt int mainColor, @ColorInt int colorPrimary, @ColorInt int colorAccent) {
+        if (isDarkThemeActive(context)) { // Dark background
+            if (ColorUtil.INSTANCE.isColorDark(mainColor)) { // Dark brand color
+                if (NotesColorUtil.contrastRatioIsSufficient(mainColor, colorPrimary)) { // But also dark text
+                    return mainColor;
+                } else {
+                    return ContextCompat.getColor(context, R.color.defaultTextHighlightBackground);
+                }
+            } else { // Light brand color
+                if (NotesColorUtil.contrastRatioIsSufficient(mainColor, colorAccent)) { // But also dark text
+                    return Color.argb(77, Color.red(mainColor), Color.green(mainColor), Color.blue(mainColor));
+                } else {
+                    return ContextCompat.getColor(context, R.color.defaultTextHighlightBackground);
+                }
+            }
+        } else { // Light background
+            if (ColorUtil.INSTANCE.isColorDark(mainColor)) { // Dark brand color
+                if (NotesColorUtil.contrastRatioIsSufficient(mainColor, colorAccent)) { // But also dark text
+                    return Color.argb(77, Color.red(mainColor), Color.green(mainColor), Color.blue(mainColor));
+                } else {
+                    return ContextCompat.getColor(context, R.color.defaultTextHighlightBackground);
+                }
+            } else { // Light brand color
+                if (NotesColorUtil.contrastRatioIsSufficient(mainColor, colorPrimary)) { // But also dark text
+                    return mainColor;
+                } else {
+                    return ContextCompat.getColor(context, R.color.defaultTextHighlightBackground);
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -1,15 +1,12 @@
 package it.niedermann.owncloud.notes.edit;
 
 import static java.lang.Boolean.TRUE;
-import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.tintMenuIcon;
 import static it.niedermann.owncloud.notes.edit.EditNoteActivity.ACTION_SHORTCUT;
 import static it.niedermann.owncloud.notes.shared.util.WidgetUtil.pendingIntentFlagCompat;
 
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -20,10 +17,8 @@ import android.view.View;
 import android.widget.ScrollView;
 
 import androidx.annotation.CallSuper;
-import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -37,10 +32,10 @@ import java.util.Calendar;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import it.niedermann.android.util.ColorUtil;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.accountpicker.AccountPickerDialogFragment;
 import it.niedermann.owncloud.notes.branding.BrandedFragment;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.edit.category.CategoryDialogFragment;
 import it.niedermann.owncloud.notes.edit.category.CategoryDialogFragment.CategoryDialogListener;
 import it.niedermann.owncloud.notes.edit.title.EditTitleDialogFragment;
@@ -53,7 +48,6 @@ import it.niedermann.owncloud.notes.shared.model.DBStatus;
 import it.niedermann.owncloud.notes.shared.model.ISyncCallback;
 import it.niedermann.owncloud.notes.shared.util.ApiVersionUtil;
 import it.niedermann.owncloud.notes.shared.util.NoteUtil;
-import it.niedermann.owncloud.notes.shared.util.NotesColorUtil;
 import it.niedermann.owncloud.notes.shared.util.ShareUtil;
 
 public abstract class BaseNoteFragment extends BrandedFragment implements CategoryDialogListener, EditTitleListener {
@@ -203,7 +197,9 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     private void prepareFavoriteOption(MenuItem item) {
         item.setIcon(note.getFavorite() ? R.drawable.ic_star_white_24dp : R.drawable.ic_star_border_white_24dp);
         item.setChecked(note.getFavorite());
-        tintMenuIcon(item, colorAccent);
+
+        final var utils = BrandingUtil.of(colorAccent, requireContext());
+        utils.platform.colorToolbarMenuIcon(requireContext(), item);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -314,8 +314,8 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -30,6 +30,7 @@ import it.niedermann.android.sharedpreferences.SharedPreferenceBooleanLiveData;
 import it.niedermann.owncloud.notes.LockedActivity;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.accountpicker.AccountPickerListener;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ActivityEditBinding;
 import it.niedermann.owncloud.notes.edit.category.CategoryViewModel;
 import it.niedermann.owncloud.notes.main.MainActivity;
@@ -314,6 +315,7 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -242,7 +242,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     }
 
     @Override
-    protected void colorWithText(@NonNull String newText, @Nullable Integer current, int mainColor, int textColor) {
+    protected void colorWithText(@NonNull String newText, @Nullable Integer current, int color) {
         if (binding != null && isAttachedToWindow(binding.editContent)) {
             binding.editContent.clearFocus();
             binding.editContent.setSearchText(newText, current);
@@ -250,12 +250,12 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        super.applyBrand(mainColor, textColor);
+    public void applyBrand(int color) {
+        super.applyBrand(color);
 
-        final var util = BrandingUtil.of(mainColor, requireContext());
-        binding.editContent.setSearchColor(mainColor);
-        binding.editContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
+        final var util = BrandingUtil.of(color, requireContext());
+        binding.editContent.setSearchColor(color);
+        binding.editContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), color, colorPrimary, colorAccent));
     }
 
     public static BaseNoteFragment newInstance(long accountId, long noteId) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -1,7 +1,6 @@
 package it.niedermann.owncloud.notes.edit;
 
 import static androidx.core.view.ViewCompat.isAttachedToWindow;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getTextHighlightBackgroundColor;
 import static it.niedermann.owncloud.notes.shared.util.NoteUtil.getFontSizeFromPreferences;
 
 import android.content.Context;
@@ -29,6 +28,7 @@ import androidx.preference.PreferenceManager;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.FragmentNoteEditBinding;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.ISyncCallback;
@@ -252,8 +252,10 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     @Override
     public void applyBrand(int mainColor, int textColor) {
         super.applyBrand(mainColor, textColor);
+
+        final var util = BrandingUtil.of(mainColor, requireContext());
         binding.editContent.setSearchColor(mainColor);
-        binding.editContent.setHighlightColor(getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
+        binding.editContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
     }
 
     public static BaseNoteFragment newInstance(long accountId, long noteId) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -17,6 +17,7 @@ import android.view.ViewGroup;
 import android.widget.ScrollView;
 import android.widget.Toast;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
@@ -138,7 +139,7 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     }
 
     @Override
-    protected void colorWithText(@NonNull String newText, @Nullable Integer current, int mainColor, int textColor) {
+    protected void colorWithText(@NonNull String newText, @Nullable Integer current, @ColorInt int color) {
         if (binding != null && isAttachedToWindow(binding.singleNoteContent)) {
             binding.singleNoteContent.clearFocus();
             binding.singleNoteContent.setSearchText(newText, current);
@@ -177,12 +178,12 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        super.applyBrand(mainColor, textColor);
+    public void applyBrand(int color) {
+        super.applyBrand(color);
 
-        final var util = BrandingUtil.of(mainColor, requireContext());
-        binding.singleNoteContent.setSearchColor(mainColor);
-        binding.singleNoteContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
+        final var util = BrandingUtil.of(color, requireContext());
+        binding.singleNoteContent.setSearchColor(color);
+        binding.singleNoteContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), color, colorPrimary, colorAccent));
     }
 
     public static BaseNoteFragment newInstance(long accountId, long noteId) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -1,7 +1,6 @@
 package it.niedermann.owncloud.notes.edit;
 
 import static androidx.core.view.ViewCompat.isAttachedToWindow;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getTextHighlightBackgroundColor;
 import static it.niedermann.owncloud.notes.shared.util.NoteUtil.getFontSizeFromPreferences;
 
 import android.content.Intent;
@@ -29,6 +28,7 @@ import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.FragmentNotePreviewBinding;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.util.SSOUtil;
@@ -179,8 +179,10 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Override
     public void applyBrand(int mainColor, int textColor) {
         super.applyBrand(mainColor, textColor);
+
+        final var util = BrandingUtil.of(mainColor, requireContext());
         binding.singleNoteContent.setSearchColor(mainColor);
-        binding.singleNoteContent.setHighlightColor(getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
+        binding.singleNoteContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), mainColor, colorPrimary, colorAccent));
     }
 
     public static BaseNoteFragment newInstance(long accountId, long noteId) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -7,11 +7,8 @@ import android.text.Layout;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewTreeObserver;
-import android.widget.LinearLayout;
-import android.widget.ScrollView;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.ColorInt;
@@ -21,11 +18,9 @@ import androidx.appcompat.widget.SearchView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.branding.BrandedActivity;
 import it.niedermann.owncloud.notes.branding.BrandingUtil;
 
 public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
@@ -41,14 +36,11 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     private static final int delay = 50; // If the search string does not change after $delay ms, then the search task starts.
 
     @ColorInt
-    private int mainColor;
-    @ColorInt
-    private int textColor;
+    private int color;
 
     @Override
     public void onStart() {
-        this.mainColor = getResources().getColor(R.color.defaultBrand);
-        this.textColor = Color.WHITE;
+        this.color = getResources().getColor(R.color.defaultBrand);
         super.onStart();
     }
 
@@ -89,12 +81,12 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
 
                 if (currentVisibility != oldVisibility) {
                     if (currentVisibility != View.VISIBLE) {
-                        colorWithText("", null, mainColor, textColor);
+                        colorWithText("", null, color);
                         searchQuery = "";
                         hideSearchFabs();
                     } else {
                         jumpToOccurrence();
-                        colorWithText(searchQuery, null, mainColor, textColor);
+                        colorWithText(searchQuery, null, color);
                         occurrenceCount = countOccurrences(getContent(), searchQuery);
                         showSearchFabs();
                     }
@@ -112,7 +104,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             next.setOnClickListener(v -> {
                 currentOccurrence++;
                 jumpToOccurrence();
-                colorWithText(searchView.getQuery().toString(), currentOccurrence, mainColor, textColor);
+                colorWithText(searchView.getQuery().toString(), currentOccurrence, color);
             });
         }
 
@@ -121,7 +113,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                 occurrenceCount = countOccurrences(getContent(), searchView.getQuery().toString());
                 currentOccurrence--;
                 jumpToOccurrence();
-                colorWithText(searchView.getQuery().toString(), currentOccurrence, mainColor, textColor);
+                colorWithText(searchView.getQuery().toString(), currentOccurrence, color);
             });
         }
 
@@ -133,7 +125,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             public boolean onQueryTextSubmit(@NonNull String query) {
                 currentOccurrence++;
                 jumpToOccurrence();
-                colorWithText(query, currentOccurrence, mainColor, textColor);
+                colorWithText(query, currentOccurrence, color);
                 return true;
             }
 
@@ -153,7 +145,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                 }
                 currentOccurrence = 1;
                 jumpToOccurrence();
-                colorWithText(searchQuery, currentOccurrence, mainColor, textColor);
+                colorWithText(searchQuery, currentOccurrence, color);
             }
 
             private void queryWithHandler(@NonNull String newText) {
@@ -199,7 +191,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         }
     }
 
-    protected abstract void colorWithText(@NonNull String newText, @Nullable Integer current, int mainColor, int textColor);
+    protected abstract void colorWithText(@NonNull String newText, @Nullable Integer current, @ColorInt int color);
 
     protected abstract Layout getLayout();
 
@@ -293,11 +285,10 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
 
     @CallSuper
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        this.mainColor = mainColor;
-        this.textColor = textColor;
+    public void applyBrand(int color) {
+        this.color = color;
 
-        final var util = BrandingUtil.of(mainColor, requireContext());
+        final var util = BrandingUtil.of(color, requireContext());
         util.material.themeFAB(getSearchNextButton());
         util.material.themeFAB(getSearchPrevButton());
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandedActivity;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 
 public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
 
@@ -295,7 +296,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     public void applyBrand(int mainColor, int textColor) {
         this.mainColor = mainColor;
         this.textColor = textColor;
-        BrandedActivity.applyBrandToFAB(mainColor, textColor, getSearchPrevButton());
-        BrandedActivity.applyBrandToFAB(mainColor, textColor, getSearchNextButton());
+
+        final var util = BrandingUtil.of(mainColor, requireContext());
+        util.material.themeFAB(getSearchNextButton());
+        util.material.themeFAB(getSearchPrevButton());
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/category/CategoryDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/category/CategoryDialogFragment.java
@@ -48,8 +48,8 @@ public class CategoryDialogFragment extends BrandedDialogFragment {
     private LiveData<List<NavigationItem.CategoryNavigationItem>> categoryLiveData;
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, requireContext());
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, requireContext());
         util.material.colorTextInputLayout(binding.inputWrapper);
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/category/CategoryDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/category/CategoryDialogFragment.java
@@ -49,7 +49,8 @@ public class CategoryDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        BrandingUtil.applyBrandToEditTextInputLayout(mainColor, binding.inputWrapper);
+        final var util = BrandingUtil.of(mainColor, requireContext());
+        util.material.colorTextInputLayout(binding.inputWrapper);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/title/EditTitleDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/title/EditTitleDialogFragment.java
@@ -86,8 +86,8 @@ public class EditTitleDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, requireContext());
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, requireContext());
         util.material.colorTextInputLayout(binding.inputWrapper);
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/title/EditTitleDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/title/EditTitleDialogFragment.java
@@ -1,7 +1,5 @@
 package it.niedermann.owncloud.notes.edit.title;
 
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.applyBrandToEditTextInputLayout;
-
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
@@ -18,6 +16,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandedDialogFragment;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.DialogEditTitleBinding;
 
 public class EditTitleDialogFragment extends BrandedDialogFragment {
@@ -88,7 +87,8 @@ public class EditTitleDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToEditTextInputLayout(mainColor, binding.inputWrapper);
+        final var util = BrandingUtil.of(mainColor, requireContext());
+        util.material.colorTextInputLayout(binding.inputWrapper);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/owncloud/notes/importaccount/ImportAccountActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/importaccount/ImportAccountActivity.java
@@ -33,7 +33,6 @@ import it.niedermann.owncloud.notes.persistence.ApiProvider;
 import it.niedermann.owncloud.notes.persistence.CapabilitiesClient;
 import it.niedermann.owncloud.notes.persistence.SyncWorker;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
-import it.niedermann.owncloud.notes.shared.model.Capabilities;
 import it.niedermann.owncloud.notes.shared.model.IResponseCallback;
 
 public class ImportAccountActivity extends AppCompatActivity {
@@ -107,7 +106,7 @@ public class ImportAccountActivity extends AppCompatActivity {
                             public void onSuccess(Account account) {
                                 runOnUiThread(() -> {
                                     Log.i(TAG, capabilities.toString());
-                                    BrandingUtil.saveBrandColors(ImportAccountActivity.this, capabilities.getColor(), capabilities.getTextColor());
+                                    BrandingUtil.saveBrandColor(ImportAccountActivity.this, capabilities.getColor());
                                     setResult(RESULT_OK);
                                     finish();
                                 });

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -6,7 +6,6 @@ import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
 import static it.niedermann.owncloud.notes.NotesApplication.isGridViewEnabled;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.DEFAULT_CATEGORY;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.FAVORITES;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.RECENT;
@@ -19,7 +18,6 @@ import android.animation.AnimatorInflater;
 import android.app.SearchManager;
 import android.content.Intent;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -71,6 +69,7 @@ import it.niedermann.owncloud.notes.accountpicker.AccountPickerListener;
 import it.niedermann.owncloud.notes.accountswitcher.AccountSwitcherDialog;
 import it.niedermann.owncloud.notes.accountswitcher.AccountSwitcherListener;
 import it.niedermann.owncloud.notes.branding.BrandedSnackbar;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ActivityNotesListViewBinding;
 import it.niedermann.owncloud.notes.databinding.DrawerLayoutBinding;
 import it.niedermann.owncloud.notes.edit.EditNoteActivity;
@@ -592,12 +591,13 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(activityBinding.appBar, activityBinding.searchToolbar);
-        applyBrandToFAB(mainColor, textColor, activityBinding.fabCreate);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.material.themeFAB(activityBinding.fabCreate);
+        util.platform.colorCircularProgressBar(activityBinding.progressCircular);
+        util.notes.applyBrandToPrimaryToolbar(activityBinding.appBar, activityBinding.searchToolbar, colorAccent);
 
         binding.headerView.setBackgroundColor(mainColor);
         binding.appName.setTextColor(textColor);
-        activityBinding.progressCircular.getIndeterminateDrawable().setColorFilter(getSecondaryForegroundColorDependingOnTheme(this, mainColor), PorterDuff.Mode.SRC_IN);
 
         // TODO We assume, that the background of the spinner is always white
         activityBinding.swiperefreshlayout.setColorSchemeColors(contrastRatioIsSufficient(Color.WHITE, mainColor) ? mainColor : Color.BLACK);

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -4,7 +4,7 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.O;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
-import static it.niedermann.owncloud.notes.NotesApplication.isDarkThemeActive;
+import static com.nextcloud.android.common.ui.util.PlatformThemeUtil.isDarkMode;
 import static it.niedermann.owncloud.notes.NotesApplication.isGridViewEnabled;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.DEFAULT_CATEGORY;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.FAVORITES;
@@ -49,6 +49,7 @@ import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.exceptions.AccountImportCancelledException;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
@@ -159,7 +160,7 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
         gridView = isGridViewEnabled();
 
-        if (!gridView || isDarkThemeActive(this)) {
+        if (!gridView || isDarkMode(this)) {
             activityBinding.activityNotesListView.setBackgroundColor(ContextCompat.getColor(this, R.color.primary));
         }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -24,6 +24,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -63,6 +64,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import it.niedermann.android.util.ColorUtil;
 import it.niedermann.owncloud.notes.LockedActivity;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.accountpicker.AccountPickerListener;
@@ -590,22 +592,22 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.material.themeFAB(activityBinding.fabCreate);
         util.platform.colorCircularProgressBar(activityBinding.progressCircular);
         util.notes.applyBrandToPrimaryToolbar(activityBinding.appBar, activityBinding.searchToolbar, colorAccent);
 
-        binding.headerView.setBackgroundColor(mainColor);
-        binding.appName.setTextColor(textColor);
+        binding.headerView.setBackgroundColor(color);
+        @ColorInt final int headerTextColor = ColorUtil.INSTANCE.getForegroundColorForBackgroundColor(color);
+        binding.appName.setTextColor(headerTextColor);
+        DrawableCompat.setTint(binding.logo.getDrawable(), headerTextColor);
 
         // TODO We assume, that the background of the spinner is always white
-        activityBinding.swiperefreshlayout.setColorSchemeColors(contrastRatioIsSufficient(Color.WHITE, mainColor) ? mainColor : Color.BLACK);
-        binding.appName.setTextColor(textColor);
-        DrawableCompat.setTint(binding.logo.getDrawable(), textColor);
+        activityBinding.swiperefreshlayout.setColorSchemeColors(contrastRatioIsSufficient(Color.WHITE, color) ? color : Color.BLACK);
 
-        adapter.applyBrand(mainColor, textColor);
-        adapterCategories.applyBrand(mainColor, textColor);
+        adapter.applyBrand(color);
+        adapterCategories.applyBrand(color);
         invalidateOptionsMenu();
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -49,6 +49,7 @@ import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.exceptions.AccountImportCancelledException;
@@ -597,7 +598,8 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
     public void applyBrand(int color) {
         final var util = BrandingUtil.of(color, this);
         util.material.themeFAB(activityBinding.fabCreate);
-        util.platform.colorCircularProgressBar(activityBinding.progressCircular);
+        util.androidx.themeSwipeRefreshLayout(activityBinding.swiperefreshlayout);
+        util.platform.colorCircularProgressBar(activityBinding.progressCircular, ColorRole.PRIMARY);
         util.platform.colorNavigationView(binding.navigationView);
         util.notes.applyBrandToPrimaryToolbar(activityBinding.appBar, activityBinding.searchToolbar, colorAccent);
 
@@ -605,9 +607,6 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
         @ColorInt final int headerTextColor = ColorUtil.INSTANCE.getForegroundColorForBackgroundColor(color);
         binding.appName.setTextColor(headerTextColor);
         DrawableCompat.setTint(binding.logo.getDrawable(), headerTextColor);
-
-        // TODO We assume, that the background of the spinner is always white
-        activityBinding.swiperefreshlayout.setColorSchemeColors(contrastRatioIsSufficient(Color.WHITE, color) ? color : Color.BLACK);
 
         adapter.applyBrand(color);
         adapterCategories.applyBrand(color);

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -122,6 +122,7 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
     protected ItemAdapter adapter;
     private NavigationAdapter adapterCategories;
+    @Nullable
     private MenuAdapter menuAdapter;
 
     private SelectionTracker<Long> tracker;
@@ -351,7 +352,7 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
                     } else {
                         startActivityForResult(menuItem.getIntent(), resultCode);
                     }
-                });
+                }, nextAccount.getColor());
 
                 binding.navigationMenu.setAdapter(menuAdapter);
             } else {
@@ -596,6 +597,7 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
         final var util = BrandingUtil.of(color, this);
         util.material.themeFAB(activityBinding.fabCreate);
         util.platform.colorCircularProgressBar(activityBinding.progressCircular);
+        util.platform.colorNavigationView(binding.navigationView);
         util.notes.applyBrandToPrimaryToolbar(activityBinding.appBar, activityBinding.searchToolbar, colorAccent);
 
         binding.headerView.setBackgroundColor(color);
@@ -608,6 +610,9 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
         adapter.applyBrand(color);
         adapterCategories.applyBrand(color);
+        if (menuAdapter != null) {
+            menuAdapter.applyBrand(color);
+        }
         invalidateOptionsMenu();
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
@@ -120,7 +120,7 @@ public class MainViewModel extends AndroidViewModel {
 
     public void postCurrentAccount(@NonNull Account account) {
         state.set(KEY_CURRENT_ACCOUNT, account);
-        BrandingUtil.saveBrandColors(getApplication(), account.getColor(), account.getTextColor());
+        BrandingUtil.saveBrandColor(getApplication(), account.getColor());
         SingleAccountHelper.setCurrentAccount(getApplication(), account.getAccountName());
 
         final var currentAccount = this.currentAccount.getValue();
@@ -410,10 +410,9 @@ public class MainViewModel extends AndroidViewModel {
                     try {
                         final var capabilities = CapabilitiesClient.getCapabilities(getApplication(), ssoAccount, localAccount.getCapabilitiesETag(), ApiProvider.getInstance());
                         repo.updateCapabilitiesETag(localAccount.getId(), capabilities.getETag());
-                        repo.updateBrand(localAccount.getId(), capabilities.getColor(), capabilities.getTextColor());
+                        repo.updateBrand(localAccount.getId(), capabilities.getColor());
                         localAccount.setColor(capabilities.getColor());
-                        localAccount.setTextColor(capabilities.getTextColor());
-                        BrandingUtil.saveBrandColors(getApplication(), localAccount.getColor(), localAccount.getTextColor());
+                        BrandingUtil.saveBrandColor(getApplication(), localAccount.getColor());
                         repo.updateApiVersion(localAccount.getId(), capabilities.getApiVersion());
                         callback.onSuccess(null);
                     } catch (Throwable t) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/ItemAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/ItemAdapter.java
@@ -1,8 +1,6 @@
 package it.niedermann.owncloud.notes.main.items;
 
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.graphics.Color;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -59,17 +57,14 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
     private final float fontSize;
     private final boolean monospace;
     @ColorInt
-    private int mainColor;
-    @ColorInt
-    private int textColor;
+    private int color;
     @Nullable
     private Integer swipedPosition;
 
     public <T extends Context & NoteClickListener> ItemAdapter(@NonNull T context, boolean gridView) {
         this.noteClickListener = context;
         this.gridView = gridView;
-        this.mainColor = ContextCompat.getColor(context, R.color.defaultBrand);
-        this.textColor = Color.WHITE;
+        this.color = ContextCompat.getColor(context, R.color.defaultBrand);
         final var sp = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         this.fontSize = getFontSizeFromPreferences(context, sp);
         this.monospace = sp.getBoolean(context.getString(R.string.pref_key_font), false);
@@ -156,7 +151,7 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
             case TYPE_NOTE_WITH_EXCERPT:
             case TYPE_NOTE_WITHOUT_EXCERPT:
             case TYPE_NOTE_ONLY_TITLE: {
-                ((NoteViewHolder) holder).bind(isSelected, (Note) itemList.get(position), showCategory, mainColor, textColor, searchQuery);
+                ((NoteViewHolder) holder).bind(isSelected, (Note) itemList.get(position), showCategory, color, searchQuery);
                 break;
             }
         }
@@ -208,9 +203,8 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        this.mainColor = mainColor;
-        this.textColor = textColor;
+    public void applyBrand(int color) {
+        this.color = color;
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -1,5 +1,9 @@
 package it.niedermann.owncloud.notes.main.items;
 
+import static android.view.View.INVISIBLE;
+import static android.view.View.VISIBLE;
+import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
+
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
@@ -34,10 +38,6 @@ import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.DBStatus;
 import it.niedermann.owncloud.notes.shared.model.NoteClickListener;
 
-import static android.view.View.INVISIBLE;
-import static android.view.View.VISIBLE;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
-
 public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
     @NonNull
     private final NoteClickListener noteClickListener;
@@ -56,7 +56,8 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
 
     protected void bindStatus(AppCompatImageView noteStatus, DBStatus status, int mainColor) {
         noteStatus.setVisibility(DBStatus.VOID.equals(status) ? INVISIBLE : VISIBLE);
-        DrawableCompat.setTint(noteStatus.getDrawable(), BrandingUtil.getSecondaryForegroundColorDependingOnTheme(noteStatus.getContext(), mainColor));
+        final var context = noteStatus.getContext();
+        DrawableCompat.setTint(noteStatus.getDrawable(), BrandingUtil.of(mainColor, context).notes.getOnPrimaryContainer(context));
     }
 
     protected void bindCategory(@NonNull Context context, @NonNull TextView noteCategory, boolean showCategory, @NonNull String category, int mainColor) {
@@ -111,13 +112,13 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
     protected void bindSearchableContent(@NonNull Context context, @NonNull TextView textView, @Nullable CharSequence searchQuery, @NonNull String content, int mainColor) {
         CharSequence processedContent = content;
         if (!TextUtils.isEmpty(searchQuery)) {
+            final var util = BrandingUtil.of(mainColor, context);
+            @ColorInt final int searchForeground = util.notes.getOnPrimaryContainer(context);
             @ColorInt final int searchBackground = ContextCompat.getColor(context, R.color.bg_highlighted);
-            @ColorInt final int searchForeground = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
 
             // The Pattern.quote method will add \Q to the very beginning of the string and \E to the end of the string
             // It implies that the string between \Q and \E is a literal string and thus the reserved keyword in such string will be ignored.
             // See https://stackoverflow.com/questions/15409296/what-is-the-use-of-pattern-quote-method
-            //noinspection ConstantConditions
             final Pattern pattern = Pattern.compile("(" + Pattern.quote(searchQuery.toString()) + ")", Pattern.CASE_INSENSITIVE);
             SpannableString spannableString = new SpannableString(content);
             Matcher matcher = pattern.matcher(spannableString);

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -53,10 +53,12 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
         itemView.setOnClickListener((view) -> noteClickListener.onNoteClick(getLayoutPosition(), view));
     }
 
-    protected void bindStatus(AppCompatImageView noteStatus, DBStatus status, int mainColor) {
+    protected void bindStatus(AppCompatImageView noteStatus, DBStatus status, int color) {
         noteStatus.setVisibility(DBStatus.VOID.equals(status) ? INVISIBLE : VISIBLE);
+
         final var context = noteStatus.getContext();
-        DrawableCompat.setTint(noteStatus.getDrawable(), BrandingUtil.of(mainColor, context).notes.getOnPrimaryContainer(context));
+        final var util = BrandingUtil.of(color, context);
+        util.platform.tintDrawable(context, noteStatus.getDrawable(), ColorRole.ON_PRIMARY_CONTAINER);
     }
 
     protected void bindCategory(@NonNull Context context, @NonNull TextView noteCategory, boolean showCategory, @NonNull String category, int color) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -2,11 +2,10 @@ package it.niedermann.owncloud.notes.main.items;
 
 import static android.view.View.INVISIBLE;
 import static android.view.View.VISIBLE;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
+
+import static com.nextcloud.android.common.ui.util.PlatformThemeUtil.isDarkMode;
 
 import android.content.Context;
-import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.BackgroundColorSpan;
@@ -26,12 +25,12 @@ import androidx.recyclerview.selection.ItemDetailsLookup;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.chip.Chip;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
+import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import it.niedermann.android.util.ColorUtil;
-import it.niedermann.owncloud.notes.NotesApplication;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
@@ -60,47 +59,26 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
         DrawableCompat.setTint(noteStatus.getDrawable(), BrandingUtil.of(mainColor, context).notes.getOnPrimaryContainer(context));
     }
 
-    protected void bindCategory(@NonNull Context context, @NonNull TextView noteCategory, boolean showCategory, @NonNull String category, int mainColor) {
-        final boolean isDarkThemeActive = NotesApplication.isDarkThemeActive(context);
-        noteCategory.setVisibility(showCategory && !category.isEmpty() ? View.VISIBLE : View.GONE);
-        noteCategory.setText(category);
+    protected void bindCategory(@NonNull Context context, @NonNull TextView noteCategory, boolean showCategory, @NonNull String category, int color) {
+        if (!showCategory || category.isEmpty()) {
+            noteCategory.setVisibility(View.GONE);
+        } else {
+            noteCategory.setText(category);
 
-        @ColorInt final int categoryForeground;
-        @ColorInt final int categoryBackground;
+            final var util = BrandingUtil.of(color, context);
 
-        if (isDarkThemeActive) {
-            if (ColorUtil.INSTANCE.isColorDark(mainColor)) {
-                if (contrastRatioIsSufficient(mainColor, Color.BLACK)) {
-                    categoryBackground = mainColor;
-                    categoryForeground = Color.WHITE;
+            if (noteCategory instanceof Chip) {
+                util.material.colorChipBackground((Chip) noteCategory);
+            } else {
+                util.platform.tintDrawable(context, noteCategory.getBackground(), ColorRole.PRIMARY);
+                if (isDarkMode(context)) {
+                    util.platform.colorTextView(noteCategory, ColorRole.ON_PRIMARY);
                 } else {
-                    categoryBackground = Color.WHITE;
-                    categoryForeground = mainColor;
+                    util.platform.colorTextView(noteCategory, ColorRole.ON_SECONDARY_CONTAINER);
                 }
-            } else {
-                categoryBackground = mainColor;
-                categoryForeground = Color.BLACK;
             }
-        } else {
-            categoryForeground = Color.BLACK;
-            if (ColorUtil.INSTANCE.isColorDark(mainColor) || contrastRatioIsSufficient(mainColor, Color.WHITE)) {
-                categoryBackground = mainColor;
-            } else {
-                categoryBackground = Color.BLACK;
-            }
-        }
 
-        noteCategory.setTextColor(categoryForeground);
-        if (noteCategory instanceof Chip) {
-            final Chip chip = (Chip) noteCategory;
-            chip.setChipStrokeColor(ColorStateList.valueOf(categoryBackground));
-            if(isDarkThemeActive) {
-                chip.setChipBackgroundColor(ColorStateList.valueOf(categoryBackground));
-            } else {
-                chip.setChipBackgroundColorResource(R.color.grid_item_background_selector);
-            }
-        } else {
-            DrawableCompat.setTint(noteCategory.getBackground(), categoryBackground);
+            noteCategory.setVisibility(View.VISIBLE);
         }
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -49,7 +49,7 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
     }
 
     @CallSuper
-    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
+    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, @ColorInt int color, @Nullable CharSequence searchQuery) {
         itemView.setSelected(isSelected);
         itemView.setOnClickListener((view) -> noteClickListener.onNoteClick(getLayoutPosition(), view));
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -89,28 +89,13 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
         noteFavorite.setOnClickListener(view -> noteClickListener.onNoteFavoriteClick(getLayoutPosition(), view));
     }
 
-    protected void bindSearchableContent(@NonNull Context context, @NonNull TextView textView, @Nullable CharSequence searchQuery, @NonNull String content, int mainColor) {
-        CharSequence processedContent = content;
+    protected void bindSearchableContent(@NonNull Context context, @NonNull TextView textView, @Nullable CharSequence searchQuery, @NonNull String content, int color) {
+        textView.setText(content);
+
         if (!TextUtils.isEmpty(searchQuery)) {
-            final var util = BrandingUtil.of(mainColor, context);
-            @ColorInt final int searchForeground = util.notes.getOnPrimaryContainer(context);
-            @ColorInt final int searchBackground = ContextCompat.getColor(context, R.color.bg_highlighted);
-
-            // The Pattern.quote method will add \Q to the very beginning of the string and \E to the end of the string
-            // It implies that the string between \Q and \E is a literal string and thus the reserved keyword in such string will be ignored.
-            // See https://stackoverflow.com/questions/15409296/what-is-the-use-of-pattern-quote-method
-            final Pattern pattern = Pattern.compile("(" + Pattern.quote(searchQuery.toString()) + ")", Pattern.CASE_INSENSITIVE);
-            SpannableString spannableString = new SpannableString(content);
-            Matcher matcher = pattern.matcher(spannableString);
-
-            while (matcher.find()) {
-                spannableString.setSpan(new ForegroundColorSpan(searchForeground), matcher.start(), matcher.end(), 0);
-                spannableString.setSpan(new BackgroundColorSpan(searchBackground), matcher.start(), matcher.end(), 0);
-            }
-
-            processedContent = spannableString;
+            final var util = BrandingUtil.of(color, context);
+            util.platform.highlightText(textView, content, searchQuery.toString());
         }
-        textView.setText(processedContent);
     }
 
     public abstract void showSwipe(boolean left);

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/grid/NoteViewGridHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/grid/NoteViewGridHolder.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.View;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
@@ -39,14 +40,14 @@ public class NoteViewGridHolder extends NoteViewHolder {
         throw new UnsupportedOperationException(NoteViewGridHolder.class.getSimpleName() + " does not support swiping");
     }
 
-    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
-        super.bind(isSelected, note, showCategory, mainColor, textColor, searchQuery);
+    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, @ColorInt int color, @Nullable CharSequence searchQuery) {
+        super.bind(isSelected, note, showCategory, color, searchQuery);
         @NonNull final Context context = itemView.getContext();
-        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), mainColor);
-        bindStatus(binding.noteStatus, note.getStatus(), mainColor);
+        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), color);
+        bindStatus(binding.noteStatus, note.getStatus(), color);
         bindFavorite(binding.noteFavorite, note.getFavorite());
-        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), mainColor);
-        bindSearchableContent(context, binding.noteExcerpt, searchQuery, note.getExcerpt().replace(EXCERPT_LINE_SEPARATOR, "\n"), mainColor);
+        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), color);
+        bindSearchableContent(context, binding.noteExcerpt, searchQuery, note.getExcerpt().replace(EXCERPT_LINE_SEPARATOR, "\n"), color);
         binding.noteExcerpt.setVisibility(TextUtils.isEmpty(note.getExcerpt()) ? GONE : VISIBLE);
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/grid/NoteViewGridHolderOnlyTitle.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/grid/NoteViewGridHolderOnlyTitle.java
@@ -32,12 +32,12 @@ public class NoteViewGridHolderOnlyTitle extends NoteViewHolder {
         throw new UnsupportedOperationException(NoteViewGridHolderOnlyTitle.class.getSimpleName() + " does not support swiping");
     }
 
-    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
-        super.bind(isSelected, note, showCategory, mainColor, textColor, searchQuery);
+    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int color, @Nullable CharSequence searchQuery) {
+        super.bind(isSelected, note, showCategory, color, searchQuery);
         @NonNull final Context context = itemView.getContext();
-        bindStatus(binding.noteStatus, note.getStatus(), mainColor);
+        bindStatus(binding.noteStatus, note.getStatus(), color);
         bindFavorite(binding.noteFavorite, note.getFavorite());
-        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), mainColor);
+        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), color);
     }
 
     @Nullable

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NoteViewHolderWithExcerpt.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NoteViewHolderWithExcerpt.java
@@ -3,6 +3,7 @@ package it.niedermann.owncloud.notes.main.items.list;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -28,16 +29,16 @@ public class NoteViewHolderWithExcerpt extends NoteViewHolder {
         binding.noteSwipeFrame.setBackgroundResource(left ? R.color.bg_warning : R.color.bg_attention);
     }
 
-    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
-        super.bind(isSelected, note, showCategory, mainColor, textColor, searchQuery);
+    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, @ColorInt int color, @Nullable CharSequence searchQuery) {
+        super.bind(isSelected, note, showCategory, color, searchQuery);
         @NonNull final var context = itemView.getContext();
         binding.noteSwipeable.setAlpha(DBStatus.LOCAL_DELETED.equals(note.getStatus()) ? 0.5f : 1.0f);
-        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), mainColor);
-        bindStatus(binding.noteStatus, note.getStatus(), mainColor);
+        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), color);
+        bindStatus(binding.noteStatus, note.getStatus(), color);
         bindFavorite(binding.noteFavorite, note.getFavorite());
 
-        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), mainColor);
-        bindSearchableContent(context, binding.noteExcerpt, searchQuery, note.getExcerpt(), mainColor);
+        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), color);
+        bindSearchableContent(context, binding.noteExcerpt, searchQuery, note.getExcerpt(), color);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NoteViewHolderWithoutExcerpt.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NoteViewHolderWithoutExcerpt.java
@@ -28,14 +28,14 @@ public class NoteViewHolderWithoutExcerpt extends NoteViewHolder {
         binding.noteSwipeFrame.setBackgroundResource(left ? R.color.bg_warning : R.color.bg_attention);
     }
 
-    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
-        super.bind(isSelected, note, showCategory, mainColor, textColor, searchQuery);
+    public void bind(boolean isSelected, @NonNull Note note, boolean showCategory, int color, @Nullable CharSequence searchQuery) {
+        super.bind(isSelected, note, showCategory, color, searchQuery);
         @NonNull final Context context = itemView.getContext();
         binding.noteSwipeable.setAlpha(DBStatus.LOCAL_DELETED.equals(note.getStatus()) ? 0.5f : 1.0f);
-        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), mainColor);
-        bindStatus(binding.noteStatus, note.getStatus(), mainColor);
+        bindCategory(context, binding.noteCategory, showCategory, note.getCategory(), color);
+        bindStatus(binding.noteStatus, note.getStatus(), color);
         bindFavorite(binding.noteFavorite, note.getFavorite());
-        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), mainColor);
+        bindSearchableContent(context, binding.noteTitle, searchQuery, note.getTitle(), color);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuAdapter.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.core.util.Consumer;
 import androidx.recyclerview.widget.RecyclerView;
@@ -17,6 +18,7 @@ import com.nextcloud.android.sso.helper.VersionCheckHelper;
 import it.niedermann.owncloud.notes.FormattingHelpActivity;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.about.AboutActivity;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ItemNavigationBinding;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
 import it.niedermann.owncloud.notes.preferences.PreferencesActivity;
@@ -25,10 +27,12 @@ public class MenuAdapter extends RecyclerView.Adapter<MenuViewHolder> {
 
     @NonNull
     private final MenuItem[] menuItems;
+    @ColorInt
+    private int color;
     @NonNull
     private final Consumer<MenuItem> onClick;
 
-    public MenuAdapter(@NonNull Context context, @NonNull Account account, int settingsRequestCode, @NonNull Consumer<MenuItem> onClick) {
+    public MenuAdapter(@NonNull Context context, @NonNull Account account, int settingsRequestCode, @NonNull Consumer<MenuItem> onClick, @ColorInt int color) {
         this.menuItems = new MenuItem[]{
                 new MenuItem(new Intent(context, FormattingHelpActivity.class), R.string.action_formatting_help, R.drawable.ic_baseline_help_outline_24),
                 new MenuItem(generateTrashbinIntent(context, account), R.string.action_trashbin, R.drawable.ic_delete_grey600_24dp),
@@ -36,7 +40,13 @@ public class MenuAdapter extends RecyclerView.Adapter<MenuViewHolder> {
                 new MenuItem(new Intent(context, AboutActivity.class), R.string.simple_about, R.drawable.ic_info_outline_grey600_24dp)
         };
         this.onClick = onClick;
+        this.color = color;
         setHasStableIds(true);
+    }
+
+    public void applyBrand(int color) {
+        this.color = color;
+        notifyDataSetChanged();
     }
 
     @Override
@@ -52,7 +62,7 @@ public class MenuAdapter extends RecyclerView.Adapter<MenuViewHolder> {
 
     @Override
     public void onBindViewHolder(@NonNull MenuViewHolder holder, int position) {
-        holder.bind(menuItems[position], onClick);
+        holder.bind(menuItems[position], color, onClick);
     }
 
     public void updateAccount(@NonNull Context context, @NonNull Account account) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuViewHolder.java
@@ -2,12 +2,14 @@ package it.niedermann.owncloud.notes.main.menu;
 
 import android.content.Context;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.util.Consumer;
 import androidx.recyclerview.widget.RecyclerView;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ItemNavigationBinding;
 
 import static android.view.View.GONE;
@@ -21,11 +23,19 @@ public class MenuViewHolder extends RecyclerView.ViewHolder {
         this.binding = binding;
     }
 
-    public void bind(@NonNull MenuItem menuItem, @NonNull Consumer<MenuItem> onClick) {
+    public void bind(@NonNull MenuItem menuItem, @ColorInt int color, @NonNull Consumer<MenuItem> onClick) {
         @NonNull Context context = itemView.getContext();
-        binding.navigationItemLabel.setText(context.getString(menuItem.getLabelResource()));
+
         binding.navigationItemIcon.setImageDrawable(ContextCompat.getDrawable(context, menuItem.getDrawableResource()));
+        binding.navigationItemLabel.setText(context.getString(menuItem.getLabelResource()));
         binding.navigationItemCount.setVisibility(GONE);
         binding.getRoot().setOnClickListener((v) -> onClick.accept(menuItem));
+
+        final var util = BrandingUtil.of(color, binding.getRoot().getContext());
+
+        util.notes.colorNavigationViewItem(binding.getRoot());
+        util.notes.colorNavigationViewItemIcon(binding.navigationItemIcon);
+        util.notes.colorNavigationViewItemText(binding.navigationItemCount);
+        util.notes.colorNavigationViewItemText(binding.navigationItemLabel);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/menu/MenuViewHolder.java
@@ -24,7 +24,6 @@ public class MenuViewHolder extends RecyclerView.ViewHolder {
     public void bind(@NonNull MenuItem menuItem, @NonNull Consumer<MenuItem> onClick) {
         @NonNull Context context = itemView.getContext();
         binding.navigationItemLabel.setText(context.getString(menuItem.getLabelResource()));
-        binding.navigationItemLabel.setTextColor(binding.getRoot().getResources().getColor(R.color.fg_default));
         binding.navigationItemIcon.setImageDrawable(ContextCompat.getDrawable(context, menuItem.getDrawableResource()));
         binding.navigationItemCount.setVisibility(GONE);
         binding.getRoot().setOnClickListener((v) -> onClick.accept(menuItem));

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
@@ -38,12 +38,6 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
     @DrawableRes
     public static final int ICON_SUB_MULTIPLE = R.drawable.ic_create_new_folder_grey600_18dp;
 
-    public void applyBrand(int color) {
-        final var util = BrandingUtil.of(color, context);
-        this.color = util.notes.getOnPrimaryContainer(context);
-        notifyDataSetChanged();
-    }
-
     @NonNull
     private List<NavigationItem> items = new ArrayList<>();
     private String selectedItem = null;
@@ -52,9 +46,13 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
 
     public NavigationAdapter(@NonNull Context context, @NonNull NavigationClickListener navigationClickListener) {
         this.context = context;
-        final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);
-        this.color = util.notes.getOnPrimaryContainer(context);
+        this.color = BrandingUtil.readBrandMainColor(context);
         this.navigationClickListener = navigationClickListener;
+    }
+
+    public void applyBrand(int color) {
+        this.color = color;
+        notifyDataSetChanged();
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
@@ -24,7 +24,7 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
     @NonNull
     private final Context context;
     @ColorInt
-    private int mainColor;
+    private int color;
     @DrawableRes
     public static final int ICON_FOLDER = R.drawable.ic_folder_grey600_24dp;
     @DrawableRes
@@ -38,9 +38,9 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
     @DrawableRes
     public static final int ICON_SUB_MULTIPLE = R.drawable.ic_create_new_folder_grey600_18dp;
 
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, context);
-        this.mainColor = util.notes.getOnPrimaryContainer(context);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, context);
+        this.color = util.notes.getOnPrimaryContainer(context);
         notifyDataSetChanged();
     }
 
@@ -53,7 +53,7 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
     public NavigationAdapter(@NonNull Context context, @NonNull NavigationClickListener navigationClickListener) {
         this.context = context;
         final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);
-        this.mainColor = util.notes.getOnPrimaryContainer(context);
+        this.color = util.notes.getOnPrimaryContainer(context);
         this.navigationClickListener = navigationClickListener;
     }
 
@@ -65,7 +65,7 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
 
     @Override
     public void onBindViewHolder(@NonNull NavigationViewHolder holder, int position) {
-        holder.bind(items.get(position), mainColor, selectedItem);
+        holder.bind(items.get(position), color, selectedItem);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationAdapter.java
@@ -1,15 +1,15 @@
 package it.niedermann.owncloud.notes.main.navigation;
 
+import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.UNCATEGORIZED;
+
 import android.content.Context;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -18,8 +18,6 @@ import java.util.List;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.main.MainActivity;
-
-import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.UNCATEGORIZED;
 
 public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder> {
 
@@ -41,7 +39,8 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
     public static final int ICON_SUB_MULTIPLE = R.drawable.ic_create_new_folder_grey600_18dp;
 
     public void applyBrand(int mainColor, int textColor) {
-        this.mainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
+        final var util = BrandingUtil.of(mainColor, context);
+        this.mainColor = util.notes.getOnPrimaryContainer(context);
         notifyDataSetChanged();
     }
 
@@ -53,7 +52,8 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationViewHolder
 
     public NavigationAdapter(@NonNull Context context, @NonNull NavigationClickListener navigationClickListener) {
         this.context = context;
-        this.mainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(context, BrandingUtil.readBrandMainColor(context));
+        final var util = BrandingUtil.of(BrandingUtil.readBrandMainColor(context), context);
+        this.mainColor = util.notes.getOnPrimaryContainer(context);
         this.navigationClickListener = navigationClickListener;
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/navigation/NavigationViewHolder.java
@@ -14,6 +14,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ItemNavigationBinding;
 import it.niedermann.owncloud.notes.shared.util.NoteUtil;
 
@@ -41,7 +42,7 @@ class NavigationViewHolder extends RecyclerView.ViewHolder {
         itemView.setOnClickListener(view -> navigationClickListener.onItemClick(currentItem));
     }
 
-    public void bind(@NonNull NavigationItem item, @ColorInt int mainColor, String selectedItem) {
+    public void bind(@NonNull NavigationItem item, @ColorInt int color, String selectedItem) {
         currentItem = item;
         final boolean isSelected = item.id.equals(selectedItem);
         name.setText(NoteUtil.extendCategory(item.label));
@@ -53,15 +54,17 @@ class NavigationViewHolder extends RecyclerView.ViewHolder {
         } else {
             icon.setVisibility(View.GONE);
         }
-        final int textColor = isSelected ? mainColor : view.getResources().getColor(R.color.fg_default);
 
-        name.setTextColor(textColor);
-        count.setTextColor(textColor);
-        icon.setColorFilter(isSelected ? textColor : 0);
+        final var util = BrandingUtil.of(color, itemView.getContext());
+
+        util.notes.colorNavigationViewItem(view);
+        util.notes.colorNavigationViewItemIcon(icon);
+        util.notes.colorNavigationViewItemText(name);
+        util.notes.colorNavigationViewItemText(count);
 
         view.setSelected(isSelected);
 
-        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        final var params = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         params.leftMargin = item.icon == NavigationAdapter.ICON_SUB_FOLDER || item.icon == NavigationAdapter.ICON_SUB_MULTIPLE
                 ? view.getResources().getDimensionPixelSize(R.dimen.spacer_3x)
                 : 0;

--- a/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountViewHolder.java
@@ -2,7 +2,6 @@ package it.niedermann.owncloud.notes.manageaccounts;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.applyBrandToLayerDrawable;
 import static it.niedermann.owncloud.notes.shared.util.ApiVersionUtil.getPreferredApiVersion;
 
 import android.graphics.drawable.LayerDrawable;
@@ -18,6 +17,7 @@ import com.bumptech.glide.request.RequestOptions;
 
 import it.niedermann.nextcloud.sso.glide.SingleSignOnUrl;
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ItemAccountChooseBinding;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
 
@@ -75,7 +75,8 @@ public class ManageAccountViewHolder extends RecyclerView.ViewHolder {
         });
         if (isCurrentAccount) {
             binding.currentAccountIndicator.setVisibility(VISIBLE);
-            applyBrandToLayerDrawable((LayerDrawable) binding.currentAccountIndicator.getDrawable(), R.id.area, localAccount.getColor());
+            final var util = BrandingUtil.of(localAccount.getColor(), itemView.getContext());
+            util.notes.colorLayerDrawable((LayerDrawable) binding.currentAccountIndicator.getDrawable(), R.id.area, localAccount.getColor());
         } else {
             binding.currentAccountIndicator.setVisibility(GONE);
         }

--- a/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountsActivity.java
@@ -208,8 +208,8 @@ public class ManageAccountsActivity extends LockedActivity implements IManageAcc
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/manageaccounts/ManageAccountsActivity.java
@@ -1,6 +1,5 @@
 package it.niedermann.owncloud.notes.manageaccounts;
 
-import static it.niedermann.owncloud.notes.branding.BrandingUtil.applyBrandToEditTextInputLayout;
 import static it.niedermann.owncloud.notes.branding.BrandingUtil.readBrandMainColorLiveData;
 import static it.niedermann.owncloud.notes.shared.util.ApiVersionUtil.getPreferredApiVersion;
 
@@ -27,6 +26,7 @@ import java.util.function.Function;
 
 import it.niedermann.owncloud.notes.LockedActivity;
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.branding.DeleteAlertDialogBuilder;
 import it.niedermann.owncloud.notes.databinding.ActivityManageAccountsBinding;
 import it.niedermann.owncloud.notes.databinding.DialogEditSettingBinding;
@@ -136,8 +136,9 @@ public class ManageAccountsActivity extends LockedActivity implements IManageAcc
         final var mainColor$ = readBrandMainColorLiveData(this);
         mainColor$.observe(this, color -> {
             mainColor$.removeObservers(this);
-            applyBrandToEditTextInputLayout(color, binding.inputWrapper);
-            binding.progress.setIndicatorColor(color);
+            final var util = BrandingUtil.of(color, this);
+            util.material.colorTextInputLayout(binding.inputWrapper);
+            util.material.colorProgressBar(binding.progress);
         });
 
         binding.inputWrapper.setHint(title);
@@ -208,6 +209,7 @@ public class ManageAccountsActivity extends LockedActivity implements IManageAcc
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/CapabilitiesWorker.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/CapabilitiesWorker.java
@@ -49,7 +49,7 @@ public class CapabilitiesWorker extends Worker {
                 Log.i(TAG, "Refreshing capabilities for " + ssoAccount.name);
                 final var capabilities = CapabilitiesClient.getCapabilities(getApplicationContext(), ssoAccount, account.getCapabilitiesETag(), ApiProvider.getInstance());
                 repo.updateCapabilitiesETag(account.getId(), capabilities.getETag());
-                repo.updateBrand(account.getId(), capabilities.getColor(), capabilities.getTextColor());
+                repo.updateBrand(account.getId(), capabilities.getColor());
                 repo.updateApiVersion(account.getId(), capabilities.getApiVersion());
                 Log.i(TAG, capabilities.toString());
                 repo.updateDisplayName(account.getId(), CapabilitiesClient.getDisplayName(getApplicationContext(), ssoAccount, ApiProvider.getInstance()));

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
@@ -34,6 +34,7 @@ import it.niedermann.owncloud.notes.persistence.migration.Migration_19_20;
 import it.niedermann.owncloud.notes.persistence.migration.Migration_20_21;
 import it.niedermann.owncloud.notes.persistence.migration.Migration_21_22;
 import it.niedermann.owncloud.notes.persistence.migration.Migration_22_23;
+import it.niedermann.owncloud.notes.persistence.migration.Migration_23_24;
 import it.niedermann.owncloud.notes.persistence.migration.Migration_9_10;
 
 @Database(
@@ -43,7 +44,7 @@ import it.niedermann.owncloud.notes.persistence.migration.Migration_9_10;
                 CategoryOptions.class,
                 SingleNoteWidgetData.class,
                 NotesListWidgetData.class
-        }, version = 23
+        }, version = 24
 )
 @TypeConverters({Converters.class})
 public abstract class NotesDatabase extends RoomDatabase {
@@ -78,7 +79,8 @@ public abstract class NotesDatabase extends RoomDatabase {
                         new Migration_19_20(context),
                         new Migration_20_21(),
                         new Migration_21_22(context),
-                        new Migration_22_23()
+                        new Migration_22_23(),
+                        new Migration_23_24(context)
                 )
                 .fallbackToDestructiveMigrationOnDowngrade()
                 .fallbackToDestructiveMigration()

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -248,8 +248,8 @@ public class NotesRepository {
         return db.getAccountDao().countAccounts$();
     }
 
-    public void updateBrand(long id, @ColorInt Integer color, @ColorInt Integer textColor) {
-        db.getAccountDao().updateBrand(id, color, textColor);
+    public void updateBrand(long id, @ColorInt Integer color) {
+        db.getAccountDao().updateBrand(id, color);
     }
 
     public void updateETag(long id, String eTag) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/AccountDao.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/AccountDao.java
@@ -42,8 +42,8 @@ public interface AccountDao {
     @Query("SELECT COUNT(*) FROM Account")
     LiveData<Integer> countAccounts$();
 
-    @Query("UPDATE Account SET COLOR = :color, TEXTCOLOR = :textColor WHERE id = :id")
-    void updateBrand(long id, @ColorInt Integer color, @ColorInt Integer textColor);
+    @Query("UPDATE Account SET COLOR = :color WHERE id = :id")
+    void updateBrand(long id, @ColorInt Integer color);
 
     @Query("UPDATE Account SET ETAG = :eTag WHERE ID = :id")
     void updateETag(long id, String eTag);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/entity/Account.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/entity/Account.java
@@ -77,7 +77,6 @@ public class Account implements Serializable {
         capabilitiesETag = capabilities.getETag();
         apiVersion = capabilities.getApiVersion();
         setColor(capabilities.getColor());
-        setTextColor(capabilities.getTextColor());
     }
 
     public long getId() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/migration/Migration_23_24.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/migration/Migration_23_24.java
@@ -1,0 +1,28 @@
+package it.niedermann.owncloud.notes.persistence.migration;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+/**
+ * Remove <code>textColor</code> property from {@link android.content.SharedPreferences} and the
+ * database as it is no longer needed for theming.
+ */
+public class Migration_23_24 extends Migration {
+
+    @NonNull
+    private final Context context;
+
+    public Migration_23_24(@NonNull Context context) {
+        super(23, 24);
+        this.context = context;
+    }
+
+    @Override
+    public void migrate(@NonNull SupportSQLiteDatabase db) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().remove("branding_text").apply();
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesActivity.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider;
 
 import it.niedermann.owncloud.notes.LockedActivity;
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.ActivityPreferencesBinding;
 
 public class PreferencesActivity extends LockedActivity {
@@ -32,6 +33,7 @@ public class PreferencesActivity extends LockedActivity {
 
     @Override
     public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar);
+        final var util = BrandingUtil.of(mainColor, this);
+        util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesActivity.java
@@ -32,8 +32,8 @@ public class PreferencesActivity extends LockedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        final var util = BrandingUtil.of(mainColor, this);
+    public void applyBrand(int color) {
+        final var util = BrandingUtil.of(color, this);
         util.notes.applyBrandToPrimaryToolbar(binding.appBar, binding.toolbar, colorAccent);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesFragment.java
@@ -115,27 +115,25 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Bra
     public void onStart() {
         super.onStart();
         final var context = requireContext();
-        @ColorInt final int mainColor = BrandingUtil.readBrandMainColor(context);
-        @ColorInt final int textColor = BrandingUtil.readBrandTextColor(context);
-        applyBrand(mainColor, textColor);
+        @ColorInt final int color = BrandingUtil.readBrandMainColor(context);
+        applyBrand(color);
     }
 
     /**
      * Change color for backgroundSyncPref as well
      * https://github.com/stefan-niedermann/nextcloud-deck/issues/531
      *
-     * @param mainColor color of main brand
-     * @param textColor color of text
+     * @param color color of main brand
      */
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        fontPref.applyBrand(mainColor, textColor);
-        lockPref.applyBrand(mainColor, textColor);
-        wifiOnlyPref.applyBrand(mainColor, textColor);
-        gridViewPref.applyBrand(mainColor, textColor);
-        preventScreenCapturePref.applyBrand(mainColor, textColor);
-        backgroundSyncPref.applyBrand(mainColor, textColor);
-        keepScreenOnPref.applyBrand(mainColor, textColor);
+    public void applyBrand(int color) {
+        fontPref.applyBrand(color);
+        lockPref.applyBrand(color);
+        wifiOnlyPref.applyBrand(color);
+        gridViewPref.applyBrand(color);
+        preventScreenCapturePref.applyBrand(color);
+        backgroundSyncPref.applyBrand(color);
+        keepScreenOnPref.applyBrand(color);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/widget/notelist/NoteListWidgetConfigurationActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/widget/notelist/NoteListWidgetConfigurationActivity.java
@@ -142,6 +142,7 @@ public class NoteListWidgetConfigurationActivity extends LockedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int color) {
+        // Nothing to do...
     }
 }

--- a/app/src/main/res/layout/drawer_layout.xml
+++ b/app/src/main/res/layout/drawer_layout.xml
@@ -14,6 +14,7 @@
         android:layout_height="match_parent" />
 
     <com.google.android.material.navigation.NavigationView
+        android:id="@+id/navigation_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"


### PR DESCRIPTION
This is an **intermediate** step to an alignment with the Material Files and Talk app.

Most important class: `BrandingUtil` - is more or less what you know as `ViewThemeUtils` in the Files app.

Something more you should know: I created also a class `NotesViewThemeUtils` as a place to put app specific styling stuff until they are available within the `android-common` library. It will probably fail because of the "No more Java" GitHub action you put in place :wink: So either we need to convert it to Kotlin or you make an exception for intermediate steps :man_shrugging: .

- The obvious stuff looks good (`FloatingActionButton`s, `EditText`s, `SwitchPreference`s and so on) and is already done via `android-common`
- Other parts like Toolbars might take some more time to iron out.

If you have own plans or think this goes into the wrong direction, please let me know.

# :eye: Screenshots

Only made with base color `#0082C9` for time reasons, but the other colors look as expected and aligned with the Files app, too.

Light | Dark
--- | ---
![grafik](https://user-images.githubusercontent.com/4741199/218306806-e0d9c7e8-8e81-49ff-b868-ed891ad1d580.png) | ![grafik](https://user-images.githubusercontent.com/4741199/218306818-8c74d72d-f33c-4f87-a9f5-b64776fc3b44.png)
![grafik](https://user-images.githubusercontent.com/4741199/218307111-b22d191b-4872-44ce-af39-5453a2fd81d1.png) | ![grafik](https://user-images.githubusercontent.com/4741199/218307085-71380965-1dbc-4cc2-ad35-08c8f1385bd3.png)
![grafik](https://user-images.githubusercontent.com/4741199/218307400-c986e84b-d3ef-4131-8f78-34b6b30b12bb.png) | ![grafik](https://user-images.githubusercontent.com/4741199/218307420-639868be-d7a1-4f0e-9724-011701c96abf.png)
![grafik](https://user-images.githubusercontent.com/4741199/218311893-cdb299c0-4787-491a-a9f0-351a737d00e2.png) | ![grafik](https://user-images.githubusercontent.com/4741199/218311920-26d495d6-5930-458b-bb50-9113046f94a1.png)
![grafik](https://user-images.githubusercontent.com/4741199/218312757-10289605-2b46-4205-91d0-63e6b64b2400.png) | ![grafik](https://user-images.githubusercontent.com/4741199/218312709-6c0a7cc2-1b8e-43b0-b74f-1312c18109a1.png)