### PR TITLE
feat: Rich editing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,7 @@ dependencies {
 
     // ReactiveX
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
     // Testing
     testImplementation 'androidx.test:core:1.5.0'

--- a/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
@@ -5,6 +5,7 @@ import static androidx.preference.PreferenceManager.getDefaultSharedPreferences;
 import android.app.Application;
 import android.content.Context;
 import android.util.Log;
+import android.webkit.WebView;
 
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
@@ -29,6 +30,9 @@ public class NotesApplication extends Application {
         lockedPreference = prefs.getBoolean(getString(R.string.pref_key_lock), false);
         isGridViewEnabled = getDefaultSharedPreferences(this).getBoolean(getString(R.string.pref_key_gridview), false);
         super.onCreate();
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true);
+        }
     }
 
     public static void setAppTheme(DarkModeSetting setting) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -71,7 +71,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     private Note originalNote;
     private int originalScrollY;
     protected NotesRepository repo;
-    private NoteFragmentListener listener;
+    protected NoteFragmentListener listener;
     private boolean titleModified = false;
 
     protected boolean isNew = true;

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -143,6 +143,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     @Nullable
     protected abstract ScrollView getScrollView();
 
+
     protected abstract void scrollToY(int scrollY);
 
     @Override
@@ -273,8 +274,15 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
                 if (scrollY > 0) {
                     note.setScrollY(scrollY);
                 }
+                onScroll(scrollY, oldScrollY);
             });
         }
+    }
+
+    /**
+     * Scroll callback, to be overridden by subclasses. Default implementation is empty
+     */
+    protected void onScroll(int scrollY, int oldScrollY) {
     }
 
     public void onCloseNote() {
@@ -367,10 +375,16 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     }
 
     public interface NoteFragmentListener {
+        enum Mode {
+            EDIT, PREVIEW, DIRECT_EDIT
+        }
+
         void close();
 
         void onNoteUpdated(Note note);
 
         void setToolbarVisibility(boolean visible);
+
+        void changeMode(@NonNull Mode mode);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -370,5 +370,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
         void close();
 
         void onNoteUpdated(Note note);
+
+        void setToolbarVisibility(boolean visible);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -107,7 +107,6 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
                         }
                         isNew = false;
                         note = originalNote = repo.getNoteById(id);
-                        Log.d(TAG, "TESTING: retrieved note: " + note);
                         requireActivity().runOnUiThread(() -> onNoteLoaded(note));
                         requireActivity().invalidateOptionsMenu();
                     } else {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -285,6 +285,10 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     protected void onScroll(int scrollY, int oldScrollY) {
     }
 
+    protected boolean shouldShowToolbar() {
+        return true;
+    }
+
     public void onCloseNote() {
         if (!titleModified && originalNote == null && getContent().isEmpty()) {
             repo.deleteNoteAndSync(localAccount, note.getId());
@@ -382,8 +386,6 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
         void close();
 
         void onNoteUpdated(Note note);
-
-        void setToolbarVisibility(boolean visible);
 
         void changeMode(@NonNull Mode mode);
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -71,6 +71,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     private Note originalNote;
     private int originalScrollY;
     protected NotesRepository repo;
+    @Nullable
     protected NoteFragmentListener listener;
     private boolean titleModified = false;
 
@@ -106,6 +107,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
                         }
                         isNew = false;
                         note = originalNote = repo.getNoteById(id);
+                        Log.d(TAG, "TESTING: retrieved note: " + note);
                         requireActivity().runOnUiThread(() -> onNoteLoaded(note));
                         requireActivity().invalidateOptionsMenu();
                     } else {
@@ -241,7 +243,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
                     .show(requireActivity().getSupportFragmentManager(), BaseNoteFragment.class.getSimpleName()));
             return true;
         } else if (itemId == R.id.menu_share) {
-            ShareUtil.openShareDialog(requireContext(), note.getTitle(), note.getContent());
+            shareNote();
             return false;
         } else if (itemId == MENU_ID_PIN) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -262,6 +264,10 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    protected void shareNote() {
+        ShareUtil.openShareDialog(requireContext(), note.getTitle(), note.getContent());
     }
 
     @CallSuper
@@ -387,6 +393,6 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
 
         void onNoteUpdated(Note note);
 
-        void changeMode(@NonNull Mode mode);
+        void changeMode(@NonNull Mode mode, boolean reloadNote);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -183,11 +183,11 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         final var prefValueLast = getString(R.string.pref_value_mode_last);
 
         final var preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        final String modePreference = preferences.getString(prefKeyNoteMode, prefValueDirectEdit);
+        final String modePreference = preferences.getString(prefKeyNoteMode, prefValueEdit);
 
         String effectiveMode = modePreference;
         if (modePreference.equals(prefValueLast)) {
-            effectiveMode = preferences.getString(prefKeyLastMode, prefValueDirectEdit);
+            effectiveMode = preferences.getString(prefKeyLastMode, prefValueEdit);
         }
 
         if (effectiveMode.equals(prefValueEdit)) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -404,7 +404,6 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
                 launchExistingNote(getAccountId(), getNoteId(), getString(R.string.pref_value_mode_preview), reloadNote);
                 break;
             case DIRECT_EDIT:
-                // TODO deal with note not created yet on server (e.g. when creating a new note in edit mode and switching to direct edit)
                 launchExistingNote(getAccountId(), getNoteId(), getString(R.string.pref_value_mode_direct_edit), reloadNote);
                 break;
             default:

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -356,7 +356,6 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
                 launchExistingNote(getAccountId(), getNoteId(), getString(R.string.pref_value_mode_preview), reloadNote);
                 break;
             case DIRECT_EDIT:
-                // TODO deal with conflict when doing some edits and then changing to direct edit
                 // TODO deal with note not created yet on server
                 launchExistingNote(getAccountId(), getNoteId(), getString(R.string.pref_value_mode_direct_edit), reloadNote);
                 break;

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.WindowManager;
 import android.widget.Toast;
 
@@ -175,14 +176,15 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         if (fragment != null) {
             savedState = getSupportFragmentManager().saveFragmentInstanceState(fragment);
         }
-        fragment = edit
-                ? NoteEditFragment.newInstance(accountId, noteId)
-                : NotePreviewFragment.newInstance(accountId, noteId);
+        // TODO switch between the three modes, don't hardcode direct edit
+        fragment = NoteDirectEditFragment.newInstance(accountId, noteId);
 
         if (savedState != null) {
             fragment.setInitialSavedState(savedState);
         }
         getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container_view, fragment).commit();
+        // TODO only hide toolbar in direct editing mode
+        binding.toolbar.setVisibility(View.GONE);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -170,6 +170,11 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
             fragment.setInitialSavedState(savedState);
         }
         getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container_view, fragment).commit();
+        if(!fragment.shouldShowToolbar()){
+            binding.toolbar.setVisibility(View.GONE);
+        }else {
+            binding.toolbar.setVisibility(View.VISIBLE);
+        }
     }
 
     private String getPreferenceMode() {
@@ -332,11 +337,6 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
                 binding.toolbar.setSubtitle(NoteUtil.extendCategory(note.getCategory()));
             }
         }
-    }
-
-    @Override
-    public void setToolbarVisibility(boolean visible) {
-        binding.toolbar.setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -1,6 +1,7 @@
 package it.niedermann.owncloud.notes.edit
 
 import android.annotation.SuppressLint
+import android.net.http.SslError
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -8,6 +9,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.JavascriptInterface
+import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
@@ -247,6 +249,19 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
                     handleLoadError()
                 }
             }
+
+            @SuppressLint("WebViewClientOnReceivedSslError") // only for debug mode
+            override fun onReceivedSslError(
+                view: WebView?,
+                handler: SslErrorHandler?,
+                error: SslError?,
+            ) {
+                if (BuildConfig.DEBUG) {
+                    handler?.proceed()
+                } else {
+                    super.onReceivedSslError(view, handler, error)
+                }
+            }
         }
     }
 
@@ -304,7 +319,6 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
 
     private fun changeToEditMode() {
         toggleLoadingUI(true)
-        // TODO clean this up a bit
         val updateDisposable = Single.just(note.remoteId)
             .map { remoteId ->
                 val newNote = notesApi.getNote(remoteId).singleOrError().blockingGet().response

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -19,12 +19,16 @@ import androidx.core.view.isVisible
 import com.nextcloud.android.sso.helper.SingleAccountHelper
 import io.reactivex.android.schedulers.AndroidSchedulers
 import it.niedermann.owncloud.notes.BuildConfig
+import it.niedermann.owncloud.notes.branding.Branded
+import it.niedermann.owncloud.notes.branding.BrandingUtil
 import it.niedermann.owncloud.notes.databinding.FragmentNoteDirectEditBinding
 import it.niedermann.owncloud.notes.persistence.DirectEditingRepository
 import it.niedermann.owncloud.notes.persistence.entity.Note
 import it.niedermann.owncloud.notes.shared.model.ISyncCallback
+import it.niedermann.owncloud.notes.shared.util.ExtendedFabUtil
+import it.niedermann.owncloud.notes.shared.util.ExtendedFabUtil.toggleVisibilityOnScroll
 
-class NoteDirectEditFragment : BaseNoteFragment() {
+class NoteDirectEditFragment : BaseNoteFragment(), Branded {
     private var _binding: FragmentNoteDirectEditBinding? = null
     private val binding: FragmentNoteDirectEditBinding
         get() = _binding!!
@@ -44,6 +48,7 @@ class NoteDirectEditFragment : BaseNoteFragment() {
     ): View {
         Log.d(TAG, "onCreateView() called")
         _binding = FragmentNoteDirectEditBinding.inflate(inflater, container, false)
+        setupFab()
         // TODO prepare webview
         setupWebSettings(binding.noteWebview.settings)
         // TODO remove this
@@ -61,6 +66,18 @@ class NoteDirectEditFragment : BaseNoteFragment() {
             "DirectEditingMobileInterface",
         )
         return binding.root
+    }
+
+    private fun setupFab() {
+        binding.plainEditingFab.isExtended = false
+        ExtendedFabUtil.toggleExtendedOnLongClick(binding.plainEditingFab)
+        binding.noteWebview.setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
+            toggleVisibilityOnScroll(binding.plainEditingFab, scrollY, oldScrollY)
+        }
+        binding.plainEditingFab.setOnClickListener {
+            // TODO save note?
+            listener.changeMode(NoteFragmentListener.Mode.EDIT)
+        }
     }
 
     override fun onDestroyView() {
@@ -147,8 +164,8 @@ class NoteDirectEditFragment : BaseNoteFragment() {
     }
 
     override fun applyBrand(color: Int) {
-        // TODO check if any branding needed
-        // nothing for now
+        val util = BrandingUtil.of(color, requireContext())
+        util.material.themeExtendedFAB(binding.plainEditingFab)
     }
 
     companion object {
@@ -194,6 +211,7 @@ class NoteDirectEditFragment : BaseNoteFragment() {
         activity?.runOnUiThread {
             binding.progress.isVisible = false
             binding.noteWebview.isVisible = true
+            binding.plainEditingFab.isVisible = true
         }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -178,8 +178,9 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
         webSettings.loadWithOverviewMode = true
 
         // user agent
-        // TODO change useragent?
-        webSettings.userAgentString = "Mozilla/5.0 (Android) Nextcloud-android/3.23.0"
+        val userAgent =
+            getString(R.string.user_agent, getString(R.string.app_name), BuildConfig.VERSION_NAME)
+        webSettings.userAgentString = userAgent
 
         // no private data storing
         webSettings.savePassword = false

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -1,0 +1,190 @@
+package it.niedermann.owncloud.notes.edit
+
+import android.annotation.SuppressLint
+import android.content.pm.ApplicationInfo
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.widget.ScrollView
+import androidx.core.view.isVisible
+import com.nextcloud.android.sso.helper.SingleAccountHelper
+import io.reactivex.android.schedulers.AndroidSchedulers
+import it.niedermann.owncloud.notes.BuildConfig
+import it.niedermann.owncloud.notes.R
+import it.niedermann.owncloud.notes.databinding.FragmentNoteDirectEditBinding
+import it.niedermann.owncloud.notes.persistence.DirectEditingRepository
+import it.niedermann.owncloud.notes.persistence.entity.Note
+import it.niedermann.owncloud.notes.shared.model.ISyncCallback
+
+class NoteDirectEditFragment : BaseNoteFragment() {
+    private var _binding: FragmentNoteDirectEditBinding? = null
+    private val binding: FragmentNoteDirectEditBinding
+        get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        menu.findItem(R.id.menu_edit).isVisible = false
+        menu.findItem(R.id.menu_preview).isVisible = true
+    }
+
+    public override fun getScrollView(): ScrollView? {
+        return null
+    }
+
+    override fun scrollToY(y: Int) {
+        // do nothing
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        Log.d(TAG, "onCreateView() called")
+        _binding = FragmentNoteDirectEditBinding.inflate(inflater, container, false)
+        // TODO prepare webview
+        setupWebSettings(binding.noteWebview.settings)
+        binding.noteWebview.addJavascriptInterface(
+            DirectEditingMobileInterface(this),
+            "DirectEditingMobileInterface",
+        )
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.noteWebview.destroy()
+        _binding = null
+    }
+
+    override fun onNoteLoaded(note: Note) {
+        super.onNoteLoaded(note)
+        Log.d(TAG, "onNoteLoaded() called with: note = $note")
+        // TODO get url and open in webview
+        val appContext = requireActivity().applicationContext
+        val repo = DirectEditingRepository.getInstance(appContext)
+        val account = SingleAccountHelper.getCurrentSingleSignOnAccount(appContext)
+        val disposable = repo.getDirectEditingUrl(account, note)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe({ url ->
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "onNoteLoaded: url = $url")
+                }
+                binding.noteWebview.loadUrl(url)
+            }, { throwable ->
+                // TODO handle error
+                Log.e(TAG, "onNoteLoaded:", throwable)
+            })
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun setupWebSettings(webSettings: WebSettings) {
+        WebView.setWebContentsDebuggingEnabled(true)
+        // enable zoom
+        webSettings.setSupportZoom(true)
+        webSettings.builtInZoomControls = true
+        webSettings.displayZoomControls = false
+
+        // Non-responsive webs are zoomed out when loaded
+        webSettings.useWideViewPort = true
+        webSettings.loadWithOverviewMode = true
+
+        // user agent
+        webSettings.setUserAgentString("Mozilla/5.0 (Android) Nextcloud-android/3.23.0")
+
+        // no private data storing
+        webSettings.savePassword = false
+        webSettings.saveFormData = false
+
+        // disable local file access
+        webSettings.allowFileAccess = false
+
+        // enable javascript
+        webSettings.javaScriptEnabled = true
+        webSettings.domStorageEnabled = true
+
+        // caching disabled in debug mode
+        if (requireActivity().applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE !== 0) {
+            binding.noteWebview.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE)
+        }
+    }
+
+    /**
+     * Gets the current content of the EditText field in the UI.
+     *
+     * @return String of the current content.
+     */
+    override fun getContent(): String {
+        // TODO what to do here?
+        return ""
+    }
+
+    override fun saveNote(callback: ISyncCallback?) {
+        // nothing, editor autosaves
+    }
+
+    override fun onCloseNote() {
+        // nothing!
+        // TODO sync note with server
+    }
+
+    override fun applyBrand(color: Int) {
+        // TODO check if any branding needed
+        // nothing for now
+    }
+
+    companion object {
+        private const val TAG = "NoteDirectEditFragment"
+
+        @JvmStatic
+        fun newInstance(accountId: Long, noteId: Long): BaseNoteFragment {
+            val fragment = NoteDirectEditFragment()
+            val args = Bundle()
+            args.putLong(PARAM_NOTE_ID, noteId)
+            args.putLong(PARAM_ACCOUNT_ID, accountId)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    private class DirectEditingMobileInterface(val noteDirectEditFragment: NoteDirectEditFragment) {
+        @JavascriptInterface
+        fun close() {
+            Log.d(TAG, "close() called")
+            // TODO callback interface or make this class anonymous
+            noteDirectEditFragment.close()
+        }
+
+        @JavascriptInterface
+        fun share() {
+            // TODO share note
+//            openShareDialog()
+        }
+
+        @JavascriptInterface
+        fun loaded() {
+            noteDirectEditFragment.onLoaded()
+        }
+    }
+
+    private fun close() {
+        listener.close()
+    }
+
+    private fun onLoaded() {
+        activity?.runOnUiThread {
+            binding.progress.isVisible = false
+            binding.noteWebview.isVisible = true
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -25,6 +25,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import it.niedermann.owncloud.notes.R;
@@ -101,6 +102,11 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     @Override
     protected FloatingActionButton getSearchPrevButton() {
         return binding.searchPrev;
+    }
+
+    @Override
+    protected @NonNull ExtendedFloatingActionButton getDirectEditingButton() {
+        return binding.directEditing;
     }
 
     @Nullable

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener;
 
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
@@ -78,6 +79,11 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Override
     protected FloatingActionButton getSearchPrevButton() {
         return binding.searchPrev;
+    }
+
+    @Override
+    protected @NonNull ExtendedFloatingActionButton getDirectEditingButton() {
+        return binding.directEditing;
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -60,11 +60,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         super.onScroll(scrollY, oldScrollY);
         if (getSearchNextButton() == null || getSearchNextButton().getVisibility() != View.VISIBLE) {
             final ExtendedFloatingActionButton directFab = getDirectEditingButton();
-            if (oldScrollY > 0 && scrollY > oldScrollY && directFab.isShown()) {
-                ExtendedFabUtil.setExtendedFabVisibility(getDirectEditingButton(), false);
-            } else if (scrollY < oldScrollY && !directFab.isShown()) {
-                ExtendedFabUtil.setExtendedFabVisibility(getDirectEditingButton(), true);
-            }
+            ExtendedFabUtil.toggleVisibilityOnScroll(directFab, scrollY, oldScrollY);
         }
     }
 
@@ -74,14 +70,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         // TODO don't show fab if direct editing not available
         final ExtendedFloatingActionButton directEditingButton = getDirectEditingButton();
         directEditingButton.setExtended(false);
-        directEditingButton.setOnLongClickListener(v -> {
-            if (directEditingButton.isExtended()) {
-                directEditingButton.shrink();
-            } else {
-                directEditingButton.extend();
-            }
-            return true;
-        });
+        ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
         directEditingButton.setOnClickListener(v -> {
             listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT);
         });

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -72,7 +72,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         directEditingButton.setExtended(false);
         ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
         directEditingButton.setOnClickListener(v -> {
-            listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT);
+            if (listener != null) {
+                listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT, true);
+            }
         });
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -83,7 +83,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
             directEditingButton.setOnClickListener(v -> {
                 if (listener != null) {
-                    listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT, true);
+                    listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT, false);
                 }
             });
         } else {

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -59,6 +59,7 @@ import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
 import com.nextcloud.android.sso.exceptions.TokenMismatchException;
 import com.nextcloud.android.sso.exceptions.UnknownErrorException;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
+import com.nextcloud.android.sso.model.SingleSignOnAccount;
 
 import java.net.HttpURLConnection;
 import java.util.LinkedList;
@@ -94,6 +95,7 @@ import it.niedermann.owncloud.notes.main.navigation.NavigationItem;
 import it.niedermann.owncloud.notes.persistence.ApiProvider;
 import it.niedermann.owncloud.notes.persistence.CapabilitiesClient;
 import it.niedermann.owncloud.notes.persistence.CapabilitiesWorker;
+import it.niedermann.owncloud.notes.persistence.DirectEditingRepository;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.CategorySortingMethod;
@@ -760,11 +762,23 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
     @Override
     public void onNoteClick(int position, View v) {
+        // TODO restore to previous behaviour, this is just for testing
         final boolean hasCheckedItems = tracker.getSelection().size() > 0;
         if (!hasCheckedItems) {
             final var note = (Note) adapter.getItem(position);
-            startActivity(new Intent(getApplicationContext(), EditNoteActivity.class)
-                    .putExtra(EditNoteActivity.PARAM_NOTE_ID, note.getId()));
+//            startActivity(new Intent(getApplicationContext(), EditNoteActivity.class)
+//                    .putExtra(EditNoteActivity.PARAM_NOTE_ID, note.getId()));
+            try {
+                final SingleSignOnAccount account = SingleAccountHelper.getCurrentSingleSignOnAccount(getApplicationContext());
+                final DirectEditingRepository repository = DirectEditingRepository.getInstance(getApplicationContext());
+                final var supported = repository.isDirectEditingSupportedByServer(account).blockingGet();
+                Log.d(TAG, "onNoteClick: direct editing is supported by server: " + supported);
+                final var directEditingUrl = repository.getDirectEditingUrl(account, note).blockingGet();
+                Log.d(TAG, "onNoteClick: direct editing url: " + directEditingUrl);
+            } catch (NoCurrentAccountSelectedException |
+                     NextcloudFilesAppAccountNotFoundException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -10,14 +10,12 @@ import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.FAVORITES;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.RECENT;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.UNCATEGORIZED;
-import static it.niedermann.owncloud.notes.shared.util.NotesColorUtil.contrastRatioIsSufficient;
 import static it.niedermann.owncloud.notes.shared.util.SSOUtil.askForNewAccount;
 
 import android.accounts.NetworkErrorException;
 import android.animation.AnimatorInflater;
 import android.app.SearchManager;
 import android.content.Intent;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -50,7 +48,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.android.common.ui.theme.utils.ColorRole;
-import com.nextcloud.android.common.ui.util.PlatformThemeUtil;
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.exceptions.AccountImportCancelledException;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
@@ -59,7 +56,6 @@ import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
 import com.nextcloud.android.sso.exceptions.TokenMismatchException;
 import com.nextcloud.android.sso.exceptions.UnknownErrorException;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
-import com.nextcloud.android.sso.model.SingleSignOnAccount;
 
 import java.net.HttpURLConnection;
 import java.util.LinkedList;
@@ -95,7 +91,6 @@ import it.niedermann.owncloud.notes.main.navigation.NavigationItem;
 import it.niedermann.owncloud.notes.persistence.ApiProvider;
 import it.niedermann.owncloud.notes.persistence.CapabilitiesClient;
 import it.niedermann.owncloud.notes.persistence.CapabilitiesWorker;
-import it.niedermann.owncloud.notes.persistence.DirectEditingRepository;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.CategorySortingMethod;
@@ -762,23 +757,11 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
 
     @Override
     public void onNoteClick(int position, View v) {
-        // TODO restore to previous behaviour, this is just for testing
         final boolean hasCheckedItems = tracker.getSelection().size() > 0;
         if (!hasCheckedItems) {
             final var note = (Note) adapter.getItem(position);
-//            startActivity(new Intent(getApplicationContext(), EditNoteActivity.class)
-//                    .putExtra(EditNoteActivity.PARAM_NOTE_ID, note.getId()));
-            try {
-                final SingleSignOnAccount account = SingleAccountHelper.getCurrentSingleSignOnAccount(getApplicationContext());
-                final DirectEditingRepository repository = DirectEditingRepository.getInstance(getApplicationContext());
-                final var supported = repository.isDirectEditingSupportedByServer(account).blockingGet();
-                Log.d(TAG, "onNoteClick: direct editing is supported by server: " + supported);
-                final var directEditingUrl = repository.getDirectEditingUrl(account, note).blockingGet();
-                Log.d(TAG, "onNoteClick: direct editing url: " + directEditingUrl);
-            } catch (NoCurrentAccountSelectedException |
-                     NextcloudFilesAppAccountNotFoundException e) {
-                throw new RuntimeException(e);
-            }
+            startActivity(new Intent(getApplicationContext(), EditNoteActivity.class)
+                    .putExtra(EditNoteActivity.PARAM_NOTE_ID, note.getId()));
         }
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
@@ -414,6 +414,7 @@ public class MainViewModel extends AndroidViewModel {
                         localAccount.setColor(capabilities.getColor());
                         BrandingUtil.saveBrandColor(getApplication(), localAccount.getColor());
                         repo.updateApiVersion(localAccount.getId(), capabilities.getApiVersion());
+                        repo.updateDirectEditingAvailable(localAccount.getId(), capabilities.isDirectEditingAvailable());
                         callback.onSuccess(null);
                     } catch (Throwable t) {
                         if (t.getClass() == NextcloudHttpRequestFailedException.class || t instanceof NextcloudHttpRequestFailedException) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/CapabilitiesWorker.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/CapabilitiesWorker.java
@@ -51,6 +51,7 @@ public class CapabilitiesWorker extends Worker {
                 repo.updateCapabilitiesETag(account.getId(), capabilities.getETag());
                 repo.updateBrand(account.getId(), capabilities.getColor());
                 repo.updateApiVersion(account.getId(), capabilities.getApiVersion());
+                repo.updateDirectEditingAvailable(account.getId(), capabilities.isDirectEditingAvailable());
                 Log.i(TAG, capabilities.toString());
                 repo.updateDisplayName(account.getId(), CapabilitiesClient.getDisplayName(getApplicationContext(), ssoAccount, ApiProvider.getInstance()));
             } catch (Throwable e) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
@@ -45,7 +45,7 @@ class DirectEditingRepository private constructor(private val applicationContext
         return Single.fromCallable {
             val call = notesRepository.getServerSettings(account, ApiVersion.API_VERSION_1_0)
             val response = call.execute()
-            response.body()?.notesPath ?: ""
+            response.body()?.notesPath ?: throw RuntimeException("No notes path available")
         }.subscribeOn(Schedulers.io())
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
@@ -1,0 +1,92 @@
+package it.niedermann.owncloud.notes.persistence
+
+import android.app.Application
+import android.content.Context
+import com.nextcloud.android.sso.model.SingleSignOnAccount
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import it.niedermann.owncloud.notes.persistence.entity.Note
+import it.niedermann.owncloud.notes.shared.model.ApiVersion
+import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingInfo
+import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingRequestBody
+
+// TODO better error handling
+class DirectEditingRepository private constructor(private val applicationContext: Context) {
+
+    private val apiProvider: ApiProvider by lazy { ApiProvider.getInstance() }
+    private val notesRepository: NotesRepository by lazy {
+        NotesRepository.getInstance(
+            applicationContext,
+        )
+    }
+
+    // TODO check for internet connection, check for directEditing supporting fileId as argument
+    fun isDirectEditingSupportedByServer(account: SingleSignOnAccount): Single<Boolean> {
+        val pathSingle = getNotesPath(account)
+        val textAvailableSingle = getDirectEditingInfo(account)
+            .map { it.editors.containsKey(SUPPORTED_EDITOR_ID) }
+
+        return Single.zip(pathSingle, textAvailableSingle) { path, textAvailable ->
+            path.isNotEmpty() && textAvailable
+        }
+    }
+
+    private fun getDirectEditingInfo(account: SingleSignOnAccount): Single<DirectEditingInfo> {
+        val filesAPI = apiProvider.getFilesAPI(applicationContext, account)
+        return Single.fromCallable {
+            val call = filesAPI.getDirectEditingInfo()
+            val response = call.execute()
+            response.body()?.ocs?.data
+                ?: throw RuntimeException("No DirectEditingInfo available")
+        }.subscribeOn(Schedulers.io())
+    }
+
+    private fun getNotesPath(account: SingleSignOnAccount): Single<String> {
+        return Single.fromCallable {
+            val call = notesRepository.getServerSettings(account, ApiVersion.API_VERSION_1_0)
+            val response = call.execute()
+            response.body()?.notesPath ?: ""
+        }.subscribeOn(Schedulers.io())
+    }
+
+    fun getDirectEditingUrl(
+        account: SingleSignOnAccount,
+        note: Note,
+    ): Single<String> {
+        return getNotesPath(account)
+            .flatMap { notesPath ->
+                val filesAPI = apiProvider.getFilesAPI(applicationContext, account)
+                Single.fromCallable {
+                    val call =
+                        filesAPI.getDirectEditingUrl(
+                            DirectEditingRequestBody(
+                                path = notesPath,
+                                editorId = SUPPORTED_EDITOR_ID,
+                                fileId = note.remoteId!!,
+                            ),
+                        )
+                    val response = call.execute()
+                    response.body()?.ocs?.data?.url
+                        ?: throw RuntimeException("No url available")
+                }.subscribeOn(Schedulers.io())
+            }
+    }
+
+    companion object {
+        private const val SUPPORTED_EDITOR_ID = "text"
+
+        private var instance: DirectEditingRepository? = null
+
+        /**
+         * @param applicationContext The application context. Do NOT use a view context to prevent leaks.
+         */
+        @JvmStatic
+        fun getInstance(applicationContext: Context): DirectEditingRepository {
+            require(applicationContext is Application)
+            if (instance == null) {
+                instance = DirectEditingRepository(applicationContext)
+            }
+            return instance!!
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/DirectEditingRepository.kt
@@ -7,10 +7,8 @@ import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import it.niedermann.owncloud.notes.persistence.entity.Note
 import it.niedermann.owncloud.notes.shared.model.ApiVersion
-import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingInfo
 import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingRequestBody
 
-// TODO better error handling
 class DirectEditingRepository private constructor(private val applicationContext: Context) {
 
     private val apiProvider: ApiProvider by lazy { ApiProvider.getInstance() }
@@ -18,27 +16,6 @@ class DirectEditingRepository private constructor(private val applicationContext
         NotesRepository.getInstance(
             applicationContext,
         )
-    }
-
-    // TODO check for internet connection, check for directEditing supporting fileId as argument
-    fun isDirectEditingSupportedByServer(account: SingleSignOnAccount): Single<Boolean> {
-        val pathSingle = getNotesPath(account)
-        val textAvailableSingle = getDirectEditingInfo(account)
-            .map { it.editors.containsKey(SUPPORTED_EDITOR_ID) }
-
-        return Single.zip(pathSingle, textAvailableSingle) { path, textAvailable ->
-            path.isNotEmpty() && textAvailable
-        }
-    }
-
-    private fun getDirectEditingInfo(account: SingleSignOnAccount): Single<DirectEditingInfo> {
-        val filesAPI = apiProvider.getFilesAPI(applicationContext, account)
-        return Single.fromCallable {
-            val call = filesAPI.getDirectEditingInfo()
-            val response = call.execute()
-            response.body()?.ocs?.data
-                ?: throw RuntimeException("No DirectEditingInfo available")
-        }.subscribeOn(Schedulers.io())
     }
 
     private fun getNotesPath(account: SingleSignOnAccount): Single<String> {

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
@@ -21,22 +21,7 @@ import it.niedermann.owncloud.notes.persistence.entity.Converters;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.persistence.entity.NotesListWidgetData;
 import it.niedermann.owncloud.notes.persistence.entity.SingleNoteWidgetData;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_10_11;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_11_12;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_12_13;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_13_14;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_14_15;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_15_16;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_16_17;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_17_18;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_18_19;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_19_20;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_20_21;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_21_22;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_22_23;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_23_24;
-import it.niedermann.owncloud.notes.persistence.migration.Migration_9_10;
-
+import it.niedermann.owncloud.notes.persistence.migration.*;
 @Database(
         entities = {
                 Account.class,
@@ -44,7 +29,7 @@ import it.niedermann.owncloud.notes.persistence.migration.Migration_9_10;
                 CategoryOptions.class,
                 SingleNoteWidgetData.class,
                 NotesListWidgetData.class
-        }, version = 24
+        }, version = 25
 )
 @TypeConverters({Converters.class})
 public abstract class NotesDatabase extends RoomDatabase {
@@ -80,7 +65,8 @@ public abstract class NotesDatabase extends RoomDatabase {
                         new Migration_20_21(),
                         new Migration_21_22(context),
                         new Migration_22_23(),
-                        new Migration_23_24(context)
+                        new Migration_23_24(context),
+                        new Migration_24_25()
                 )
                 .fallbackToDestructiveMigrationOnDowngrade()
                 .fallbackToDestructiveMigration()

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -263,6 +263,9 @@ public class NotesRepository {
     public void updateModified(long id, long modified) {
         db.getAccountDao().updateModified(id, modified);
     }
+    public void updateDirectEditingAvailable(final long id, final boolean available) {
+        db.getAccountDao().updateDirectEditingAvailable(id, available);
+    }
 
 
     // Notes

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/AccountDao.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/AccountDao.java
@@ -21,8 +21,8 @@ public interface AccountDao {
     @Delete
     void deleteAccount(Account localAccount);
 
-    String getAccounts = "SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName FROM Account";
-    String getAccountById = "SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName FROM Account WHERE ID = :accountId";
+    String getAccounts = "SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName, directEditingAvailable FROM Account";
+    String getAccountById = "SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName, directEditingAvailable FROM Account WHERE ID = :accountId";
 
     @Query(getAccounts)
     LiveData<List<Account>> getAccounts$();
@@ -36,7 +36,7 @@ public interface AccountDao {
     @Query(getAccountById)
     Account getAccountById(long accountId);
 
-    @Query("SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName FROM Account WHERE ACCOUNTNAME = :accountName")
+    @Query("SELECT id, url, userName, accountName, eTag, modified, apiVersion, color, textColor, capabilitiesEtag, COALESCE(displayName, userName) as displayName, directEditingAvailable FROM Account WHERE ACCOUNTNAME = :accountName")
     Account getAccountByName(String accountName);
 
     @Query("SELECT COUNT(*) FROM Account")
@@ -59,4 +59,7 @@ public interface AccountDao {
 
     @Query("UPDATE Account SET DISPLAYNAME = :displayName WHERE id = :id")
     void updateDisplayName(long id, @Nullable String displayName);
+
+    @Query("UPDATE Account SET directEditingAvailable = :available WHERE id = :id")
+    void updateDirectEditingAvailable(long id, boolean available);
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/entity/Account.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/entity/Account.java
@@ -10,17 +10,9 @@ import androidx.room.Entity;
 import androidx.room.Index;
 import androidx.room.PrimaryKey;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-
 import java.io.Serializable;
 import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.NoSuchElementException;
 
-import it.niedermann.owncloud.notes.shared.model.ApiVersion;
 import it.niedermann.owncloud.notes.shared.model.Capabilities;
 
 @Entity(
@@ -60,6 +52,7 @@ public class Account implements Serializable {
     private String capabilitiesETag;
     @Nullable
     private String displayName;
+    private boolean directEditingAvailable;
 
     public Account() {
         // Default constructor
@@ -76,6 +69,7 @@ public class Account implements Serializable {
     public void setCapabilities(@NonNull Capabilities capabilities) {
         capabilitiesETag = capabilities.getETag();
         apiVersion = capabilities.getApiVersion();
+        directEditingAvailable = capabilities.isDirectEditingAvailable();
         setColor(capabilities.getColor());
     }
 
@@ -175,6 +169,14 @@ public class Account implements Serializable {
         this.displayName = displayName;
     }
 
+    public boolean isDirectEditingAvailable() {
+        return directEditingAvailable;
+    }
+
+    public void setDirectEditingAvailable(boolean directEditingAvailable) {
+        this.directEditingAvailable = directEditingAvailable;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -195,6 +197,7 @@ public class Account implements Serializable {
             return false;
         if (capabilitiesETag != null ? !capabilitiesETag.equals(account.capabilitiesETag) : account.capabilitiesETag != null)
             return false;
+        if (directEditingAvailable != account.directEditingAvailable) return false;
         return true;
     }
 
@@ -210,6 +213,7 @@ public class Account implements Serializable {
         result = 31 * result + color;
         result = 31 * result + textColor;
         result = 31 * result + (capabilitiesETag != null ? capabilitiesETag.hashCode() : 0);
+        result = 31 * result + (directEditingAvailable ? 1 : 0);
         return result;
     }
 
@@ -227,6 +231,7 @@ public class Account implements Serializable {
                 ", color=" + color +
                 ", textColor=" + textColor +
                 ", capabilitiesETag='" + capabilitiesETag + '\'' +
+                ", directEditingAvailable='" + directEditingAvailable + '\'' +
                 '}';
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/migration/Migration_24_25.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/migration/Migration_24_25.kt
@@ -1,0 +1,13 @@
+package it.niedermann.owncloud.notes.persistence.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Suppress("ClassName", "Detekt.ClassNaming", "Detekt.MagicNumber")
+class Migration_24_25 : Migration(24, 25) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE Account ADD COLUMN directEditingAvailable INTEGER DEFAULT 0 NOT NULL")
+        // remove capabilities etag to force refresh
+        db.execSQL("UPDATE Account SET capabilitiesETag = NULL")
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
@@ -31,6 +31,9 @@ public class CapabilitiesDeserializer implements JsonDeserializer<Capabilities> 
     private static final String CAPABILITIES_THEMING = "theming";
     private static final String CAPABILITIES_THEMING_COLOR = "color";
     private static final String CAPABILITIES_THEMING_COLOR_TEXT = "color-text";
+    private static final String CAPABILITIES_FILES = "files";
+    private static final String CAPABILITIES_FILES_DIRECT_EDITING = "directEditing";
+    private static final String CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID = "supportsFileId";
 
     @Override
     public Capabilities deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
@@ -61,7 +64,21 @@ public class CapabilitiesDeserializer implements JsonDeserializer<Capabilities> 
                     }
                 }
             }
+            response.setDirectEditingAvailable(hasDirectEditingCapability(capabilities));
         }
         return response;
+    }
+
+    private boolean hasDirectEditingCapability(final JsonObject capabilities) {
+        if (capabilities.has(CAPABILITIES_FILES)) {
+            final var files = capabilities.getAsJsonObject(CAPABILITIES_FILES);
+            if (files.has(CAPABILITIES_FILES_DIRECT_EDITING)) {
+                final var directEditing = files.getAsJsonObject(CAPABILITIES_FILES_DIRECT_EDITING);
+                if (directEditing.has(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID)) {
+                    return directEditing.get(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID).getAsBoolean();
+                }
+            }
+        }
+        return false;
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/FilesAPI.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/FilesAPI.kt
@@ -1,0 +1,18 @@
+package it.niedermann.owncloud.notes.persistence.sync
+
+import it.niedermann.owncloud.notes.shared.model.OcsResponse
+import it.niedermann.owncloud.notes.shared.model.OcsUrl
+import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingInfo
+import it.niedermann.owncloud.notes.shared.model.directediting.DirectEditingRequestBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface FilesAPI {
+    @GET("directEditing?format=json")
+    fun getDirectEditingInfo(): Call<OcsResponse<DirectEditingInfo>>
+
+    @POST("directEditing/open?format=json")
+    fun getDirectEditingUrl(@Body body: DirectEditingRequestBody): Call<OcsResponse<OcsUrl>>
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/Capabilities.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/Capabilities.java
@@ -3,7 +3,6 @@ package it.niedermann.owncloud.notes.shared.model;
 import android.graphics.Color;
 
 import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public class Capabilities {
@@ -15,6 +14,8 @@ public class Capabilities {
     private int textColor = Color.WHITE;
     @Nullable
     private String eTag;
+
+    private boolean directEditingAvailable;
 
     public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
@@ -49,7 +50,15 @@ public class Capabilities {
         this.textColor = textColor;
     }
 
-    @NonNull
+
+    public boolean isDirectEditingAvailable() {
+        return directEditingAvailable;
+    }
+
+    public void setDirectEditingAvailable(boolean directEditingAvailable) {
+        this.directEditingAvailable = directEditingAvailable;
+    }
+
     @Override
     public String toString() {
         return "Capabilities{" +
@@ -57,6 +66,7 @@ public class Capabilities {
                 ", color=" + color +
                 ", textColor=" + textColor +
                 ", eTag='" + eTag + '\'' +
+                ", hasDirectEditing=" + directEditingAvailable +
                 '}';
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/OcsUrl.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/OcsUrl.kt
@@ -1,0 +1,9 @@
+package it.niedermann.owncloud.notes.shared.model
+
+import com.google.gson.annotations.Expose
+
+data class OcsUrl(
+    @Expose
+    @JvmField
+    var url: String? = null
+)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingCreator.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingCreator.kt
@@ -1,0 +1,18 @@
+package it.niedermann.owncloud.notes.shared.model.directediting
+
+import com.google.gson.annotations.Expose
+
+data class DirectEditingCreator(
+    @Expose
+    val id: String,
+    @Expose
+    val editor: String,
+    @Expose
+    val name: String,
+    @Expose
+    val extension: String,
+    @Expose
+    val mimetype: String,
+    @Expose
+    val templates: Boolean,
+)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingEditor.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingEditor.kt
@@ -1,0 +1,19 @@
+package it.niedermann.owncloud.notes.shared.model.directediting
+
+import com.google.gson.annotations.Expose
+
+/**
+ * Editor for direct editing data model
+ */
+data class DirectEditingEditor(
+    @Expose
+    val id: String,
+    @Expose
+    val name: String,
+    @Expose
+    val mimetypes: ArrayList<String>,
+    @Expose
+    val optionalMimetypes: ArrayList<String>,
+    @Expose
+    val secure: Boolean,
+)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingInfo.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingInfo.kt
@@ -1,0 +1,10 @@
+package it.niedermann.owncloud.notes.shared.model.directediting
+
+import com.google.gson.annotations.Expose
+
+data class DirectEditingInfo(
+    @Expose
+    val editors: Map<String, DirectEditingEditor>,
+    @Expose
+    val creators: Map<String, DirectEditingCreator>,
+)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingRequestBody.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/model/directediting/DirectEditingRequestBody.kt
@@ -1,0 +1,12 @@
+package it.niedermann.owncloud.notes.shared.model.directediting
+
+import com.google.gson.annotations.Expose
+
+data class DirectEditingRequestBody(
+    @Expose
+    val path: String,
+    @Expose
+    val editorId: String,
+    @Expose
+    val fileId: Long,
+)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
@@ -8,7 +8,7 @@ import com.google.android.material.floatingactionbutton.ExtendedFloatingActionBu
 
 object ExtendedFabUtil {
     @JvmStatic
-    public fun setExtendedFabVisibility(
+    fun setExtendedFabVisibility(
         extendedFab: ExtendedFloatingActionButton,
         visibility: Boolean,
     ) {
@@ -34,6 +34,32 @@ object ExtendedFabUtil {
                     extendedFab.startAnimation(animation)
                 }
             }
+        }
+    }
+
+    @JvmStatic
+    fun toggleExtendedOnLongClick(extendedFab: ExtendedFloatingActionButton) {
+        extendedFab.setOnLongClickListener { v: View? ->
+            if (extendedFab.isExtended) {
+                extendedFab.shrink()
+            } else {
+                extendedFab.extend()
+            }
+            true
+        }
+    }
+
+    @JvmStatic
+    fun toggleVisibilityOnScroll(
+        extendedFab: ExtendedFloatingActionButton,
+        scrollY: Int,
+        oldScrollY: Int,
+    ) {
+        @Suppress("ConvertTwoComparisonsToRangeCheck")
+        if (oldScrollY > 0 && scrollY > oldScrollY && extendedFab.isShown) {
+            setExtendedFabVisibility(extendedFab, false)
+        } else if (scrollY < oldScrollY && !extendedFab.isShown) {
+            setExtendedFabVisibility(extendedFab, true)
         }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
@@ -1,0 +1,39 @@
+package it.niedermann.owncloud.notes.shared.util
+
+import android.view.View
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import com.google.android.material.R
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+
+object ExtendedFabUtil {
+    @JvmStatic
+    public fun setExtendedFabVisibility(
+        extendedFab: ExtendedFloatingActionButton,
+        visibility: Boolean,
+    ) {
+        if (visibility) {
+            extendedFab.show()
+        } else {
+            if (extendedFab.isExtended) {
+                extendedFab.hide()
+            } else {
+                if (extendedFab.animation == null) {
+                    val animation = AnimationUtils.loadAnimation(
+                        extendedFab.context,
+                        R.anim.abc_shrink_fade_out_from_bottom,
+                    )
+                    animation.setAnimationListener(object : Animation.AnimationListener {
+                        override fun onAnimationStart(animation: Animation) {}
+                        override fun onAnimationEnd(animation: Animation) {
+                            extendedFab.visibility = View.GONE
+                        }
+
+                        override fun onAnimationRepeat(animation: Animation) {}
+                    })
+                    extendedFab.startAnimation(animation)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/rx/DisposableSet.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/rx/DisposableSet.kt
@@ -1,0 +1,16 @@
+package it.niedermann.owncloud.notes.shared.util.rx
+
+import io.reactivex.disposables.Disposable
+
+class DisposableSet {
+    private val disposables = mutableSetOf<Disposable>()
+
+    fun add(disposable: Disposable) {
+        disposables.add(disposable)
+    }
+
+    fun dispose() {
+        disposables.forEach { it.dispose() }
+        disposables.clear()
+    }
+}

--- a/app/src/main/res/drawable/ic_notes.xml
+++ b/app/src/main/res/drawable/ic_notes.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,18h12v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h18v-2L3,11v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_rich_editing.xml
+++ b/app/src/main/res/drawable/ic_rich_editing.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright Andreas Gohr
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,7H9V13H3V7M3,3H21V5H3V3M21,7V9H11V7H21M21,11V13H11V11H21M3,15H17V17H3V15M3,19H21V21H3V19Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_note_direct_edit.xml
+++ b/app/src/main/res/layout/fragment_note_direct_edit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:visibility="gone"
+        android:id="@+id/note_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!--    TODO FABs? Search?-->
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_note_direct_edit.xml
+++ b/app/src/main/res/layout/fragment_note_direct_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent">
 
@@ -8,7 +9,8 @@
         android:visibility="gone"
         android:id="@+id/note_webview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        tools:visibility="visible" />
 
     <ProgressBar
         android:id="@+id/progress"
@@ -19,5 +21,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!--    TODO FABs? Search?-->
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/plain_editing_fab"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/noteMode_plain_edit"
+        android:text="@string/noteMode_plain_edit"
+        android:visibility="gone"
+        app:backgroundTint="@color/defaultBrand"
+        app:icon="@drawable/ic_notes"
+        app:layout_anchor="@id/note_webview"
+        app:layout_anchorGravity="bottom|end"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_note_edit.xml
+++ b/app/src/main/res/layout/fragment_note_edit.xml
@@ -64,4 +64,19 @@
         app:backgroundTint="@color/defaultBrand"
         app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
         tools:visibility="visible" />
+
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/direct_editing"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/noteMode_rich_edit"
+        android:text="@string/noteMode_rich_edit"
+        android:visibility="visible"
+        app:backgroundTint="@color/defaultBrand"
+        app:layout_anchor="@id/scrollView"
+        app:layout_anchorGravity="bottom|end"
+        app:icon="@drawable/ic_rich_editing" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_note_preview.xml
+++ b/app/src/main/res/layout/fragment_note_preview.xml
@@ -61,4 +61,19 @@
         app:backgroundTint="@color/defaultBrand"
         app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
         tools:visibility="visible" />
+
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/direct_editing"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/noteMode_rich_edit"
+        android:text="@string/noteMode_rich_edit"
+        android:visibility="visible"
+        app:backgroundTint="@color/defaultBrand"
+        app:layout_anchor="@id/scrollView"
+        app:layout_anchorGravity="bottom|end"
+        app:icon="@drawable/ic_rich_editing" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -3,6 +3,7 @@
     <string-array name="noteMode_values">
         <item>@string/pref_value_mode_edit</item>
         <item>@string/pref_value_mode_preview</item>
+        <item>@string/pref_value_mode_direct_edit</item>
         <item>@string/pref_value_mode_last</item>
     </string-array>
     <string-array name="fontSize_values">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,4 +368,5 @@
     <string name="account_imported">Account imported.</string>
     <string name="direct_editing_error">Error while loading rich editing</string>
     <string name="switch_to_plain_editing">Switch to plain editing</string>
+    <string name="action_back">Back</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,4 +369,5 @@
     <string name="direct_editing_error">Error while loading rich editing</string>
     <string name="switch_to_plain_editing">Switch to plain editing</string>
     <string name="action_back">Back</string>
+    <string name="user_agent" translatable="false">Mozilla/5.0 (Android) %1$s-android/%2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,17 +215,17 @@
     <string name="manage_accounts">Manage accounts</string>
     <string name="action_formatting_help">Formatting</string>
 
-    <string-array name="noteMode_entries">
-        <item>Open in edit mode</item>
-        <item>Open in preview mode</item>
-        <item>Remember my last selection</item>
-    </string-array>
 
-    <string-array name="noteMode_entries_new">
-        <item>Plain edit mode</item>
-        <item>Plain preview</item>
-        <item>Rich edit mode</item>
-        <item>Remember my last selection</item>
+    <string name="noteMode_plain_edit">Plain edit mode</string>
+    <string name="noteMode_plain_preview">Plain preview</string>
+    <string name="noteMode_rich_edit">Rich edit mode</string>
+    <string name="noteMode_remember_last">Remember my last selection</string>
+
+    <string-array name="noteMode_entries_new" translatable="false">
+        <item>@string/noteMode_plain_edit</item>
+        <item>@string/noteMode_plain_preview</item>
+        <item>@string/noteMode_rich_edit</item>
+        <item>@string/noteMode_remember_last</item>
     </string-array>
 
     <string-array name="fontSize_entries">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,4 +366,6 @@
     <string name="progress_import_indeterminate">Importing notes…</string>
     <string name="progress_import">Importing note %1$d of %2$d…</string>
     <string name="account_imported">Account imported.</string>
+    <string name="direct_editing_error">Error while loading rich editing</string>
+    <string name="switch_to_plain_editing">Switch to plain editing</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="listview_updated_last_month">Last month</string>
 
     <string name="settings_note_mode">Display mode for notes</string>
+    <string name="settings_note_mode_new">Notes opening behaviour</string>
     <string name="settings_theme_title">Theme</string>
     <string name="settings_font_title">Monospace font</string>
     <string name="settings_font_size">Font size</string>
@@ -122,6 +123,7 @@
     <string name="pref_key_last_note_mode" translatable="false">lastNoteMode</string>
     <string name="pref_key_background_sync" translatable="false">backgroundSync</string>
     <string name="pref_value_mode_edit" translatable="false">edit</string>
+    <string name="pref_value_mode_direct_edit" translatable="false">directEdit</string>
     <string name="pref_value_mode_preview" translatable="false">preview</string>
     <string name="pref_value_mode_last" translatable="false">last</string>
     <string name="pref_value_font_size_small" translatable="false">small</string>
@@ -216,6 +218,13 @@
     <string-array name="noteMode_entries">
         <item>Open in edit mode</item>
         <item>Open in preview mode</item>
+        <item>Remember my last selection</item>
+    </string-array>
+
+    <string-array name="noteMode_entries_new">
+        <item>Plain edit mode</item>
+        <item>Plain preview</item>
+        <item>Rich edit mode</item>
         <item>Remember my last selection</item>
     </string-array>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -35,6 +35,16 @@
             android:summary="%s"
             android:title="@string/settings_theme_title" />
 
+        <ListPreference
+            android:defaultValue="@string/pref_value_mode_last"
+            android:entries="@array/noteMode_entries_new"
+            android:entryValues="@array/noteMode_values"
+            android:icon="@drawable/ic_remove_red_eye_grey_24dp"
+            android:key="@string/pref_key_note_mode"
+            android:layout="@layout/item_pref"
+            android:summary="%s"
+            android:title="@string/settings_note_mode_new" />
+
         <it.niedermann.owncloud.notes.branding.BrandedSwitchPreference
             android:icon="@drawable/ic_baseline_dashboard_24"
             android:key="@string/pref_key_gridview"
@@ -57,16 +67,6 @@
             android:layout="@layout/item_pref"
             android:summary="%s"
             android:title="@string/settings_font_size" />
-
-        <ListPreference
-            android:defaultValue="@string/pref_value_mode_edit"
-            android:entries="@array/noteMode_entries"
-            android:entryValues="@array/noteMode_values"
-            android:icon="@drawable/ic_remove_red_eye_grey_24dp"
-            android:key="@string/pref_key_note_mode"
-            android:layout="@layout/item_pref"
-            android:summary="%s"
-            android:title="@string/settings_note_mode" />
 
         <it.niedermann.owncloud.notes.branding.BrandedSwitchPreference
             android:defaultValue="true"

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
@@ -1,5 +1,10 @@
 package it.niedermann.owncloud.notes.persistence.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import android.graphics.Color;
 
 import com.google.gson.JsonParser;
@@ -7,11 +12,6 @@ import com.google.gson.JsonParser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
-import it.niedermann.owncloud.notes.shared.model.Capabilities;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class CapabilitiesDeserializerTest {
@@ -305,5 +305,59 @@ public class CapabilitiesDeserializerTest {
         assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
         assertEquals(Color.parseColor("#44616B"), capabilities.getColor());
         assertEquals(Color.parseColor("#ffffff"), capabilities.getTextColor());
+        assertFalse("Wrongly reporting that direct editing is supported", capabilities.isDirectEditingAvailable());
+    }
+
+
+    @Test
+    public void testDirectEditing() {
+        //language=json
+        final String responseOk = "" +
+                "{" +
+                "    \"version\":{" +
+                "        \"major\":18," +
+                "        \"minor\":0," +
+                "        \"micro\":4," +
+                "        \"string\":\"18.0.4\"," +
+                "        \"edition\":\"\"," +
+                "        \"extendedSupport\":false" +
+                "    }," +
+                "    \"capabilities\":{" +
+                "        \"files\": {" +
+                "            \"directEditing\": {" +
+                "                \"url\": \"https://nextcloud.example.com/ocs/v2.php/apps/files/api/v1/directEditing\"," +
+                "                \"etag\": \"6226ba873373f5e73a3ef504107523f7\"," +
+                "                \"supportsFileId\": true" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities = deserializer.deserialize(JsonParser.parseString(responseOk), null, null);
+        assertTrue("Direct editing should be considered supported", capabilities.isDirectEditingAvailable());
+
+        //language=json
+        final String responseNotOk = "" +
+                "{" +
+                "    \"version\":{" +
+                "        \"major\":18," +
+                "        \"minor\":0," +
+                "        \"micro\":4," +
+                "        \"string\":\"18.0.4\"," +
+                "        \"edition\":\"\"," +
+                "        \"extendedSupport\":false" +
+                "    }," +
+                "    \"capabilities\":{" +
+                "        \"files\": {" +
+                "            \"directEditing\": {" +
+                "                \"url\": \"https://nextcloud.example.com/ocs/v2.php/apps/files/api/v1/directEditing\"," +
+                "                \"etag\": \"6226ba873373f5e73a3ef504107523f7\"," +
+                "                \"supportsFileId\": false" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities1 = deserializer.deserialize(JsonParser.parseString(responseNotOk), null, null);
+        assertFalse("Wrongly reporting that direct editing is supported", capabilities1.isDirectEditingAvailable());
+
     }
 }


### PR DESCRIPTION
- [x] Fetch and store direct editing capability
    - [x] Use capability to toggle whether direct editing option is available 
- [x] Fetch remote editing info/URL for notes
    - [x] Needs https://github.com/nextcloud/server/pull/36727. Check capability / server version?
- [x] Open notes with remote editing in webview WIP
    - [x] existing notes
    - [x] new notes
- [x] Allow changing mode to rich editing from plain edit/preview
- [x]  Allow changing to plain edit from rich edit
- [x] Error handling

Copied from #1645:

- [x] in settings "display mode for notes"
  - [x] new name: Notes opening behaviour
     - plain edit mode
     - plain preview
     - rich edit mode
     - remember last selection
  - [x] move as second option (after Theme)
  - [x] first open in plain edit mode
  - [x] default: remember last selection
- [x] show FAB while editing note
  - icon: with https://pictogrammers.com/library/mdi/icon/format-float-left
  - add license in svg/xml file: apache 2.0, with Andreas Gohr
  - FAB hides when scrolling
  - long press "rich editing"
  - https://m3.material.io/components/floating-action-button/overview
  - click opens webview fullscreen
    - via direct editing remote operation
    - within in webview
      - FAB, icon: https://fonts.google.com/icons?selected=Material+Icons:notes
      - click on FAB goes to plain edit/view note
    - closes (x) back to list
(discussed alternative: not fullscreen, hide search, redefine x vs back button)



Fixes #1645