### PR TITLE
Allow the user to disable direct-editing

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -115,6 +115,11 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         return binding.directEditing;
     }
 
+    protected ExtendedFloatingActionButton getNormalEditButton() {
+        // the edit fragment does not have a button
+        return null;
+    }
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -58,6 +58,10 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.menu_edit).setVisible(true);
+        if(getNormalEditButton().getVisibility() == View.VISIBLE) {
+            menu.findItem(R.id.menu_edit).setVisible(false);
+        }
+
         menu.findItem(R.id.menu_preview).setVisible(false);
     }
 
@@ -90,6 +94,11 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Override
     protected @NonNull ExtendedFloatingActionButton getDirectEditingButton() {
         return binding.directEditing;
+    }
+
+    @Override
+    protected ExtendedFloatingActionButton getNormalEditButton() {
+        return binding.edit;
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -85,7 +85,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         checkDirectEditingAvailable();
-        if (directEditAvailable) {
+        if (directEditAvailable && isDirectEditEnabled()) {
             final ExtendedFloatingActionButton directEditingButton = getDirectEditingButton();
             directEditingButton.setExtended(false);
             ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
@@ -96,6 +96,15 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             });
         } else {
             getDirectEditingButton().setVisibility(View.GONE);
+            ExtendedFloatingActionButton edit = getNormalEditButton();
+            if(edit!=null) {
+                edit.setVisibility(View.VISIBLE);
+                edit.setOnClickListener(v -> {
+                    if (listener != null) {
+                        listener.changeMode(NoteFragmentListener.Mode.EDIT, true);
+                    }
+                });
+            }
         }
     }
 
@@ -108,6 +117,14 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             Log.w(TAG, "checkDirectEditingAvailable: ", e);
             directEditAvailable = false;
         }
+    }
+
+    protected boolean isDirectEditEnabled() {
+        if (!directEditAvailable) {
+            return false;
+        }
+        //todo: handle preference here
+        return false;
     }
 
     @Override
@@ -258,6 +275,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     @NonNull
     protected abstract ExtendedFloatingActionButton getDirectEditingButton();
 
+    protected abstract ExtendedFloatingActionButton getNormalEditButton();
 
     private void showSearchFabs() {
         ExtendedFabUtil.setExtendedFabVisibility(getDirectEditingButton(), false);
@@ -353,5 +371,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         util.material.themeFAB(getSearchNextButton());
         util.material.themeFAB(getSearchPrevButton());
         util.material.themeExtendedFAB(getDirectEditingButton());
+        var editFab = getNormalEditButton();
+        if(editFab != null) {
+            util.material.themeExtendedFAB(editFab);
+        }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/preferences/PreferencesFragment.java
@@ -40,6 +40,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Bra
     private BrandedSwitchPreference preventScreenCapturePref;
     private BrandedSwitchPreference backgroundSyncPref;
     private BrandedSwitchPreference keepScreenOnPref;
+    private BrandedSwitchPreference enableDirectEditorPref;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -114,6 +115,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Bra
             SyncWorker.update(requireContext(), (Boolean) newValue);
             return true;
         });
+
+        enableDirectEditorPref = findPreference(getString(R.string.pref_key_enable_direct_edit));
     }
 
 
@@ -141,5 +144,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Bra
         preventScreenCapturePref.applyBrand(color);
         backgroundSyncPref.applyBrand(color);
         keepScreenOnPref.applyBrand(color);
+        enableDirectEditorPref.applyBrand(color);
     }
 }

--- a/app/src/main/res/drawable/ic_rich_editing_grey600_24dp.xml
+++ b/app/src/main/res/drawable/ic_rich_editing_grey600_24dp.xml
@@ -1,17 +1,9 @@
 <!--
-Copyright Andreas Gohr
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  ~ Nextcloud Notes - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+  ~ SPDX-FileCopyrightText: 2021 Andreas Gohr
+  ~ SPDX-License-Identifier: Apache-2.0
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"

--- a/app/src/main/res/drawable/ic_rich_editing_grey600_24dp.xml
+++ b/app/src/main/res/drawable/ic_rich_editing_grey600_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright Andreas Gohr
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF757575"
+        android:pathData="M3,7H9V13H3V7M3,3H21V5H3V3M21,7V9H11V7H21M21,11V13H11V11H21M3,15H17V17H3V15M3,19H21V21H3V19Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_note_preview.xml
+++ b/app/src/main/res/layout/fragment_note_preview.xml
@@ -81,4 +81,19 @@
         app:layout_anchor="@id/scrollView"
         app:layout_anchorGravity="bottom|end"
         app:icon="@drawable/ic_rich_editing" />
+
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/edit"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/noteMode_plain_edit"
+        android:text="@string/noteMode_plain_edit"
+        android:visibility="visible"
+        app:backgroundTint="@color/defaultBrand"
+        app:layout_anchor="@id/scrollView"
+        app:layout_anchorGravity="bottom|end"
+        app:icon="@drawable/ic_edit_grey600_24dp" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="settings_prevent_screen_capture">Prevent screen capture</string>
     <string name="settings_gridview">Grid view</string>
     <string name="settings_enable_direct_edit">Direct Edit</string>
-    <string name="settings_enable_direct_edit_summary">When disabled, we will not show the advanced editor.</string>
+    <string name="settings_enable_direct_edit_summary">When disabled, the advanced editor will be hidden.</string>
     <string name="settings_keep_screen_on">Keep screen on</string>
     <string name="settings_keep_screen_on_summary">When viewing or editing a note</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="settings_background_sync">Background synchronization</string>
     <string name="settings_prevent_screen_capture">Prevent screen capture</string>
     <string name="settings_gridview">Grid view</string>
+    <string name="settings_enable_direct_edit">Direct Edit</string>
+    <string name="settings_enable_direct_edit_summary">When disabled, we will not show the advanced editor.</string>
     <string name="settings_keep_screen_on">Keep screen on</string>
     <string name="settings_keep_screen_on_summary">When viewing or editing a note</string>
 
@@ -127,6 +129,7 @@
     <string name="pref_category_security" translatable="false">security</string>
     <string name="pref_key_last_note_mode" translatable="false">lastNoteMode</string>
     <string name="pref_key_background_sync" translatable="false">backgroundSync</string>
+    <string name="pref_key_enable_direct_edit" translatable="false">directEditPreference</string>
     <string name="pref_value_mode_edit" translatable="false">edit</string>
     <string name="pref_value_mode_direct_edit" translatable="false">directEdit</string>
     <string name="pref_value_mode_preview" translatable="false">preview</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -53,6 +53,15 @@
             android:title="@string/settings_note_mode_new" />
 
         <it.niedermann.owncloud.notes.branding.BrandedSwitchPreference
+            android:defaultValue="true"
+            android:icon="@drawable/ic_rich_editing_grey600_24dp"
+            android:key="@string/pref_key_enable_direct_edit"
+            android:layout="@layout/item_pref"
+            android:title="@string/settings_enable_direct_edit"
+            android:summary="@string/settings_enable_direct_edit_summary" />
+
+
+        <it.niedermann.owncloud.notes.branding.BrandedSwitchPreference
             android:icon="@drawable/ic_baseline_dashboard_24"
             android:key="@string/pref_key_gridview"
             android:layout="@layout/item_pref"


### PR DESCRIPTION
Implements #1819

This PR implements a toggle that changes the behaviour of the edit-fragment.

Original:
Notes-fragment has a fab that allows the user to open rich editing. In the toolbar is a pen for the local editor. The pen changes to an eye if in edit mode.

Now:
If rich text is enabled (which is the default), the ui does not change.
If it is not enabled, the fab is now a button to open the local editor. In the editor, no fab is shown, but the eye-icon as before.

