### PR TITLE
Checkboxes in Widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,15 +20,21 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:targetApi="n">
+        <receiver
+            android:name=".reciever.WidgetCheckboxReciever"
+            android:enabled="true"
+            android:exported="true" />
 
         <activity
             android:name=".main.MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.App.Starting"
-            android:exported="true">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
+
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
 
@@ -39,64 +45,64 @@
                 android:name="android.app.default_searchable"
                 android:value=".android.activity.NotesListViewActivity" />
         </activity>
-
         <activity
             android:name=".importaccount.ImportAccountActivity"
             android:label="@string/add_account" />
-
         <activity
             android:name=".AppendToNoteActivity"
-            android:label="@string/append_to_note"
-            android:exported="true">
+            android:exported="true"
+            android:label="@string/append_to_note">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/*" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".exception.ExceptionActivity"
             android:label="@string/app_name" />
-
         <activity
             android:name=".FormattingHelpActivity"
             android:label="@string/action_formatting_help"
             android:parentActivityName=".main.MainActivity"
             android:windowSoftInputMode="stateHidden" />
-
         <activity
             android:name=".manageaccounts.ManageAccountsActivity"
             android:label="@string/manage_accounts"
             android:parentActivityName=".main.MainActivity"
             android:windowSoftInputMode="stateHidden" />
-
         <activity
             android:name=".preferences.PreferencesActivity"
             android:label="@string/action_settings"
             android:parentActivityName=".main.MainActivity"
             android:windowSoftInputMode="stateHidden" />
-
         <activity
             android:name=".edit.EditNoteActivity"
+            android:exported="true"
             android:label="@string/simple_edit"
             android:launchMode="singleTask"
             android:parentActivityName=".main.MainActivity"
-            android:windowSoftInputMode="stateHidden"
-            android:exported="true">
+            android:windowSoftInputMode="stateHidden">
             <intent-filter android:label="@string/action_create">
                 <action android:name="android.intent.action.SEND" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <!-- Voice command "note to self" in google search -->
             <intent-filter android:label="@string/action_create">
                 <action android:name="com.google.android.gm.action.AUTO_SEND" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
 
                 <data android:scheme="content" />
@@ -104,22 +110,20 @@
                 <data android:mimeType="text/*" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".about.AboutActivity"
             android:label="@string/simple_about"
             android:parentActivityName=".main.MainActivity" />
-
-        <activity android:name=".widget.singlenote.SingleNoteWidgetConfigurationActivity"
+        <activity
+            android:name=".widget.singlenote.SingleNoteWidgetConfigurationActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
-
-        <activity android:name=".widget.notelist.NoteListWidgetConfigurationActivity"
+        <activity
+            android:name=".widget.notelist.NoteListWidgetConfigurationActivity"
             android:exported="true">
-
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
@@ -127,9 +131,8 @@
 
         <receiver
             android:name=".widget.singlenote.SingleNoteWidget"
-            android:label="@string/widget_single_note_title"
-            android:exported="true">
-
+            android:exported="true"
+            android:label="@string/widget_single_note_title">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -138,12 +141,10 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/single_note_widget_provider_info" />
         </receiver>
-
         <receiver
             android:name=".widget.notelist.NoteListWidget"
-            android:label="@string/widget_note_list_title"
-            android:exported="true">
-
+            android:exported="true"
+            android:label="@string/widget_note_list_title">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -156,22 +157,20 @@
         <service
             android:name=".widget.singlenote.SingleNoteWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
-
         <service
             android:name=".widget.notelist.NoteListWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
-
         <service
             android:name=".quicksettings.NewNoteTileService"
             android:description="@string/action_create"
+            android:exported="true"
             android:icon="@drawable/ic_launcher_foreground_full"
             android:label="@string/action_create"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
-            android:exported="true">
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
-
     </application>
+
 </manifest>

--- a/app/src/main/java/it/niedermann/owncloud/notes/reciever/WidgetCheckboxReciever.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/reciever/WidgetCheckboxReciever.kt
@@ -1,0 +1,14 @@
+package it.niedermann.owncloud.notes.reciever
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class WidgetCheckboxReciever : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        // This method is called when the BroadcastReceiver is receiving an Intent broadcast.
+        Log.e("RECIEVER", "Action: ${intent.action}")
+    }
+}

--- a/app/src/main/res/layout-v31/widget_single_note_content.xml
+++ b/app/src/main/res/layout-v31/widget_single_note_content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/single_note_content_tv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingMultiplier="@dimen/note_line_spacing"
+        android:textColor="@color/widget_foreground"
+        android:visibility="gone"
+        tools:text="@tools:sample/lorem/random" />
+
+    <CheckBox
+        android:id="@+id/single_note_content_cb"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:visibility="gone"
+        android:text="CheckBox" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/widget_single_note.xml
+++ b/app/src/main/res/layout/widget_single_note.xml
@@ -11,6 +11,8 @@
         android:layout_height="match_parent"
         android:paddingVertical="@dimen/widget_inner_padding_vertical"
         android:paddingHorizontal="@dimen/widget_inner_padding_horizontal"
+        android:dividerHeight="0dp"
+        android:divider="@null"
         tools:listitem="@layout/widget_single_note_content" />
 
     <TextView

--- a/app/src/main/res/layout/widget_single_note_content.xml
+++ b/app/src/main/res/layout/widget_single_note_content.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:tools="http://schemas.android.com/tools"
+android:layout_width="match_parent"
+android:layout_height="wrap_content"
+android:orientation="vertical">
+
+<TextView
     android:id="@+id/single_note_content_tv"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:lineSpacingMultiplier="@dimen/note_line_spacing"
     android:textColor="@color/widget_foreground"
+    android:visibility="gone"
     tools:text="@tools:sample/lorem/random" />
+
+</LinearLayout>


### PR DESCRIPTION
Fixes #1907 
Requires: https://github.com/stefan-niedermann/nextcloud-commons/pull/215

This implements checkable-checkboxes on devices with api 31 or greater.

![image](https://github.com/nextcloud/notes-android/assets/25279821/b40442be-f1b4-4e29-af2f-59edc5a9e531)

This is a first working prototype.
It can:
- Display a checkbox for chechbox items
- Handle the state correctly

It cannot:
- Display checkbox-text nice. The raw-markdown is currently not stripped
- Send a checkbox event back to the app
- Render the notes good. (With each markdown block, there is a margin at the bottom)


Since this requires changes in the nextcloud-common library, i would like to ask for a general review now, before i continue.
