### PR TITLE
Hardening: Remove specific taskAffinity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,13 +19,15 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:targetApi="n">
+        tools:targetApi="n"
+        android:taskAffinity="">
 
         <activity
             android:name=".main.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/Theme.App.Starting"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Removing specific taskAffinity and setting launchMode to "singleInstance" makes sure that no other app can start activities in their task/ context.