### PR TITLE
Remove Launchmode to create editNoteActivity in same task stack

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
             android:name=".main.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/Theme.App.Starting"
-            android:exported="true"
-            android:launchMode="singleInstance">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -88,7 +87,6 @@
         <activity
             android:name=".edit.EditNoteActivity"
             android:label="@string/simple_edit"
-            android:launchMode="singleTask"
             android:parentActivityName=".main.MainActivity"
             android:windowSoftInputMode="stateHidden"
             android:exported="true">


### PR DESCRIPTION
Bug described in issue https://github.com/nextcloud/notes-android/issues/2124 was introduced by https://github.com/nextcloud/notes-android/pull/2018 and can be seen in this Video: 


https://github.com/nextcloud/notes-android/assets/43114340/06506286-e6bb-4d9f-aca0-5a9df02613b4



When removing launchmode this specific bug is fixed (can be seen in this video) but it may introduce new bugs that should be collected here:


https://github.com/nextcloud/notes-android/assets/43114340/9c4d0823-bfcb-45ff-85fd-52b3fa113ac4

### For the reviewers
Please test carefully behaviours where new activities are started or switched!
