### PR TITLE
PoC: Provides toolbar for native markdown editor

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/NotesViewThemeUtils.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.util.Log;
 import android.view.View;
@@ -26,6 +27,8 @@ import androidx.appcompat.widget.AppCompatAutoCompleteTextView;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.BlendModeColorFilterCompat;
+import androidx.core.graphics.BlendModeCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
@@ -35,7 +38,11 @@ import com.nextcloud.android.common.ui.theme.MaterialSchemes;
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase;
 import com.nextcloud.android.common.ui.theme.utils.MaterialViewThemeUtils;
 
+import java.util.Optional;
+
+import dynamiccolor.DynamicScheme;
 import dynamiccolor.MaterialDynamicColors;
+import it.niedermann.android.markdown.controller.MarkdownToolbarController;
 import it.niedermann.android.util.ColorUtil;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.main.navigation.NavigationItem;
@@ -190,8 +197,8 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
     }
 
     /**
-     * @deprecated Should be replaced with {@link com.google.android.material.search.SearchView}
      * @see com.nextcloud.android.common.ui.theme.utils.AndroidXViewThemeUtils#themeToolbarSearchView(SearchView)
+     * @deprecated Should be replaced with {@link com.google.android.material.search.SearchView}
      */
     @Deprecated
     public void themeToolbarSearchView(@NonNull SearchView searchView) {
@@ -208,5 +215,25 @@ public class NotesViewThemeUtils extends ViewThemeUtilsBase {
             searchButton.setColorFilter(dynamicColor.onSurface().getArgb(scheme));
             return searchView;
         });
+    }
+
+    public void themeToolbar(@NonNull Toolbar toolbar) {
+        withScheme(toolbar, scheme -> {
+            toolbar.setBackgroundColor(dynamicColor.surface().getArgb(scheme));
+//            toolbar.setNavigationIconTint(dynamicColor.onSurface().getArgb(scheme));
+            toolbar.setTitleTextColor(dynamicColor.onSurface().getArgb(scheme));
+            final var overflowIcon = Optional.ofNullable(toolbar.getOverflowIcon());
+            overflowIcon.ifPresent(drawable -> colorTrailingIcon(scheme, drawable));
+            return toolbar;
+        });
+    }
+
+    private void colorTrailingIcon(@NonNull DynamicScheme scheme,
+                                   @NonNull Drawable icon) {
+        icon.setColorFilter(
+                BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+                        dynamicColor.surfaceVariant().getArgb(scheme),
+                        BlendModeCompat.SRC_ATOP
+                ));
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -34,6 +34,7 @@ import androidx.preference.PreferenceManager;
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
+import it.niedermann.android.markdown.controller.ControllerConnector;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.databinding.FragmentNoteEditBinding;
@@ -124,6 +125,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentNoteEditBinding.inflate(inflater, container, false);
+        ControllerConnector.connect(getViewLifecycleOwner(), binding.editContent, binding.controller);
         return binding.getRoot();
     }
 
@@ -272,6 +274,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
 
         final var util = BrandingUtil.of(color, requireContext());
         binding.editContent.setSearchColor(color);
+        util.notes.themeToolbar(binding.controller);
         binding.editContent.setHighlightColor(util.notes.getTextHighlightBackgroundColor(requireContext(), color, colorPrimary, colorAccent));
     }
 

--- a/app/src/main/res/layout/fragment_note_edit.xml
+++ b/app/src/main/res/layout/fragment_note_edit.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  ~ Nextcloud Notes - Android Client
  ~
  ~ SPDX-FileCopyrightText: 2015-2024 Nextcloud GmbH and Nextcloud contributors
@@ -20,68 +19,94 @@
         android:focusableInTouchMode="true"
         android:orientation="horizontal" />
 
-    <ScrollView
-        android:id="@+id/scrollView"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true"
-        android:orientation="vertical"
-        tools:context="it.niedermann.owncloud.notes.edit.EditNoteActivity">
+        android:orientation="vertical">
 
-        <it.niedermann.android.markdown.MarkdownEditorImpl
-            android:id="@+id/editContent"
+        <ScrollView
+            android:id="@+id/scrollView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:fillViewport="true"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@id/controller"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:context="it.niedermann.owncloud.notes.edit.EditNoteActivity">
+
+            <it.niedermann.android.markdown.MarkdownEditorImpl
+                android:id="@+id/editContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/spacer_activity_sides"
+                android:background="@android:color/transparent"
+                android:ems="10"
+                android:gravity="top"
+                android:inputType="textMultiLine|textCapSentences"
+                android:lineSpacingMultiplier="@dimen/note_line_spacing"
+                android:padding="@dimen/spacer_2x"
+                android:textColor="@color/fg_default"
+                tools:text="@tools:sample/lorem/random" />
+        </ScrollView>
+
+        <it.niedermann.android.markdown.controller.MarkdownToolbarController
+            android:id="@+id/controller"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/spacer_activity_sides"
-            android:background="@android:color/transparent"
-            android:ems="10"
-            android:gravity="top"
-            android:inputType="textMultiLine|textCapSentences"
-            android:lineSpacingMultiplier="@dimen/note_line_spacing"
-            android:padding="@dimen/spacer_2x"
-            android:textColor="@color/fg_default"
-            tools:text="@tools:sample/lorem/random" />
-    </ScrollView>
+            android:gravity="bottom"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:menu="@menu/toolbar" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/searchPrev"
-        style="?attr/floatingActionButtonSmallSecondaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/simple_prev"
-        android:translationY="-56dp"
-        android:visibility="gone"
-        app:backgroundTint="@color/defaultBrand"
-        app:srcCompat="@drawable/ic_keyboard_arrow_up_white_24dp"
-        tools:visibility="visible" />
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/searchPrev"
+            style="?attr/floatingActionButtonSmallSecondaryStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/spacer_2x"
+            android:contentDescription="@string/simple_prev"
+            android:translationY="-56dp"
+            android:visibility="gone"
+            app:backgroundTint="@color/defaultBrand"
+            app:layout_constraintBottom_toTopOf="@id/controller"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/ic_keyboard_arrow_up_white_24dp"
+            tools:visibility="visible" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/searchNext"
-        style="?attr/floatingActionButtonSmallSecondaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/simple_next"
-        android:visibility="gone"
-        app:backgroundTint="@color/defaultBrand"
-        app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
-        tools:visibility="visible" />
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/searchNext"
+            style="?attr/floatingActionButtonSmallSecondaryStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/spacer_2x"
+            android:contentDescription="@string/simple_next"
+            android:visibility="gone"
+            app:backgroundTint="@color/defaultBrand"
+            app:layout_constraintBottom_toTopOf="@id/controller"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
+            tools:visibility="visible" />
 
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/direct_editing"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/noteMode_rich_edit"
-        android:text="@string/noteMode_rich_edit"
-        android:visibility="visible"
-        app:backgroundTint="@color/defaultBrand"
-        app:layout_anchor="@id/scrollView"
-        app:layout_anchorGravity="bottom|end"
-        app:icon="@drawable/ic_rich_editing" />
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/direct_editing"
+            style="?attr/floatingActionButtonPrimaryStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/spacer_2x"
+            android:contentDescription="@string/noteMode_rich_edit"
+            android:text="@string/noteMode_rich_edit"
+            android:visibility="visible"
+            app:backgroundTint="@color/defaultBrand"
+            app:icon="@drawable/ic_rich_editing"
+            app:layout_anchor="@id/scrollView"
+            app:layout_anchorGravity="bottom|end"
+            app:layout_constraintBottom_toTopOf="@id/controller"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Currently the toolbar is positioned below the content so
- the actions are reachable more ergonomically and
- the additional vertical gap when switching between preview and edit mode can be avoided
However, the collaborative rich editor shows its menu bar above the content.

Which way should we go? Consistency vs. ergonomics? Or would you even consider to switch the toolbar position for the collaborative rich editor?

CC @tobiasKaminsky @AndyScherzinger

| _ | _ |
| --- | --- |
| ![Screenshot_20240523_113405](https://github.com/nextcloud/notes-android/assets/4741199/51e39dc0-7f4e-4bec-820e-7fa626812d1a) | ![Screenshot_20240523_114309](https://github.com/nextcloud/notes-android/assets/4741199/a2fa8819-ac5f-4aed-a71d-de65692158c6) |

Please note that the toolbar integration *might* still have some bugs left which would need to be addressed in the `stefan-niedermann:nextcloud-commons` library.