### PR TITLE
Fix debouncing not working on first search character; add extra delay instead

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -228,8 +228,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                     handler.removeCallbacksAndMessages(null);
                 }
                 delayQueryTask = new DelayQueryRunnable(newText);
-                // If there is only one char in the search pattern, we should start the search immediately.
-                handler.postDelayed(delayQueryTask, newText.length() > 1 ? delay : 0);
+                handler.postDelayed(delayQueryTask, delay);
             }
 
             class DelayQueryRunnable implements Runnable {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -48,6 +48,8 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     private SearchView searchView;
     private String searchQuery = null;
     private static final int delay = 50; // If the search string does not change after $delay ms, then the search task starts.
+    private static final int shortStringDelay = 200; // A longer delay for short search strings.
+    private static final int shortStringSize = 3; // The maximum length of a short search string.
     private boolean directEditRemotelyAvailable = false; // avoid using this directly, instead use: isDirectEditEnabled()
 
     @ColorInt
@@ -228,7 +230,8 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                     handler.removeCallbacksAndMessages(null);
                 }
                 delayQueryTask = new DelayQueryRunnable(newText);
-                handler.postDelayed(delayQueryTask, delay);
+                // If there are few chars in the search pattern, we should start the search later.
+                handler.postDelayed(delayQueryTask, newText.length() > shortStringSize ? delay : shortStringDelay);
             }
 
             class DelayQueryRunnable implements Runnable {


### PR DESCRIPTION
For some unknown reason, debouncing was specifically avoided for the first character. This is weird because it's where debouncing is needed most, especially for long files where a single-character search can hang the app for a long time.

I don't think this will fix everything about long-running searches, but debouncing all characters will at least match expectations, allowing people to attempt to type quickly to avoid them.

Since 50ms seemed very quick (a three-frame window at 60 fps), I decided to use a longer delay (200ms) for short searches three characters long or less. The original delay is retained for other lengths, where interactive incremental behavior is more useful and won't hang the app if it happens accidentally.

Should partially address #1729 and #769.