### PR TITLE
fix: unable to edit from preview mode

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -87,8 +87,11 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         super.onViewCreated(view, savedInstanceState);
         checkDirectEditingAvailable();
         if (isDirectEditEnabled()) {
+            ExtendedFloatingActionButton edit = getNormalEditButton();
+            if (edit != null) edit.setVisibility(View.GONE);
             final ExtendedFloatingActionButton directEditingButton = getDirectEditingButton();
             directEditingButton.setExtended(false);
+            directEditingButton.setVisibility(View.VISIBLE);
             ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
             directEditingButton.setOnClickListener(v -> {
                 if (listener != null) {


### PR DESCRIPTION
When direct edit is enabled and note opening behavior is set to either plain edit mode or plain preview the note cannot be edited from the preview fragment. This is because of visibility settings of the two FABs not being set properly. 

Since the normal edit button was never set to invisible the rich editor FAB was hidden. Also the visibility flag is used to determine the visibility of the plain edit button in the action bar in `NotePreviewFragement.onPrepareOptionsMenu()`. So what users were left with is the inability to edit notes. 

fixes #2372
fixes #2258