### PR TITLE
Bugfix/Correct sort descending lexicographical

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -262,8 +262,13 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
             updateSortMethodIcon(methodOfCategory.second);
             activityBinding.sortingMethod.setOnClickListener((v) -> {
                 if (methodOfCategory.first != null) {
+                    int newId = 0;
+                    if (methodOfCategory.second != null)
+                    {
+                        newId = methodOfCategory.second.getId();
+                    }
                     //Rotate for next sorting method
-                    var newMethod = CategorySortingMethod.findById(methodOfCategory.second.getId() + 1);
+                    var newMethod = CategorySortingMethod.findById(newId + 1);
                     final var modifyLiveData = mainViewModel.modifyCategoryOrder(methodOfCategory.first, newMethod);
                     modifyLiveData.observe(this, (next) -> modifyLiveData.removeObservers(this));
                 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
@@ -16,7 +16,7 @@ import static it.niedermann.owncloud.notes.main.slots.SlotterUtil.fillListByCate
 import static it.niedermann.owncloud.notes.main.slots.SlotterUtil.fillListByInitials;
 import static it.niedermann.owncloud.notes.main.slots.SlotterUtil.fillListByTime;
 import static it.niedermann.owncloud.notes.shared.model.CategorySortingMethod.SORT_MODIFIED_DESC;
-import static it.niedermann.owncloud.notes.shared.model.CategorySortingMethod.SORT_LEXICOGRAPHICAL_ASC;
+import static it.niedermann.owncloud.notes.shared.model.CategorySortingMethod.SORT_LEXICOGRAPHICAL_DESC;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.DEFAULT_CATEGORY;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.FAVORITES;
 import static it.niedermann.owncloud.notes.shared.model.ENavigationCategoryType.RECENT;
@@ -273,6 +273,9 @@ public class MainViewModel extends AndroidViewModel {
     }
 
     private List<Item> fromNotes(List<Note> noteList, @NonNull NavigationCategory selectedCategory, @Nullable CategorySortingMethod sortingMethod) {
+        if(sortingMethod == SORT_LEXICOGRAPHICAL_DESC){
+            Collections.reverse(noteList);
+        }
         if (selectedCategory.getType() == DEFAULT_CATEGORY) {
             final String category = selectedCategory.getCategory();
             if (category != null) {
@@ -283,9 +286,6 @@ public class MainViewModel extends AndroidViewModel {
         }
         if (sortingMethod == SORT_MODIFIED_DESC) {
             return fillListByTime(getApplication(), noteList);
-        }
-        if(sortingMethod != SORT_LEXICOGRAPHICAL_ASC){
-            Collections.reverse(noteList);
         }
         return fillListByInitials(getApplication(), noteList);
     }

--- a/app/src/main/res/drawable/alphabetical_desc.xml
+++ b/app/src/main/res/drawable/alphabetical_desc.xml
@@ -4,6 +4,7 @@
   ~
   ~ SPDX-FileCopyrightText: 2018-2024 Google LLC
   ~ SPDX-FileCopyrightText: 2018-2024 Andy Scherzinger
+  ~ SPDX-FileCopyrightText: 2024-2025 Kornél Szekeres
   ~ SPDX-License-Identifier: Apache-2.0
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
This PR addresses a bug in my initial descending lexicographical sorting implementation (#2487) where:

🐛 Bug:

Null pointer exception during category sort swich.

Incomplete sorting logic for lexicographical descending sort.

🔧 Fix:

Check for null ptr and initailize for 0.

Sorting applied for category filtering too.

Maintains backward compatibility

✅ Verification:

Validated on my phone with android studio

Confirmed no-breaking changes