### PR TITLE
BugFix - Empty Note Content

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -544,10 +544,15 @@ public class NotesRepository {
     public void toggleFavoriteAndSync(Account account, Note note) {
         executor.submit(() -> {
             try {
+                final var noteWithContent = getNoteById(note.getId());
+                if (noteWithContent == null) {
+                    return;
+                }
+
                 final var ssoAccount = AccountImporter.getSingleSignOnAccount(context, account.getAccountName());
                 final var notesAPI = apiProvider.getNotesAPI(context, ssoAccount, getPreferredApiVersion(account.getApiVersion()));
-                note.setFavorite(!note.getFavorite());
-                final var result = notesAPI.updateNote(note);
+                noteWithContent.setFavorite(!noteWithContent.getFavorite());
+                final var result = notesAPI.updateNote(noteWithContent);
                 final var response = result.execute();
                 if (response.isSuccessful()) {
                     final var updatedNote = response.body();


### PR DESCRIPTION
Somehow, the `toggleFavoriteAndSync(Account account, Note note)` method is being called with a Note parameter that doesn't contain the content. Thus, `noteWithContent` used from DB. 

Adapter item is used in that function. We can check that adapter logic in different PR.

https://github.com/user-attachments/assets/86bb55bc-1ce7-413e-8731-20e0ea28bd49

