### PR TITLE
Fix syncing if sharing is disabled server side. Fixes #2733.

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
@@ -71,15 +71,18 @@ public class CapabilitiesDeserializer implements JsonDeserializer<Capabilities> 
                 response.setFederationShare(outgoing.getAsBoolean());
 
                 final var publicObject = filesSharing.getAsJsonObject("public");
-                final var password = publicObject.getAsJsonObject("password");
-                final var enforced = password.getAsJsonPrimitive("enforced");
-                final var askForOptionalPassword = password.getAsJsonPrimitive("askForOptionalPassword");
+                if (publicObject.has("password")) {
+                    final var password = publicObject.getAsJsonObject("password");
+                    final var enforced = password.getAsJsonPrimitive("enforced");
+                    final var askForOptionalPassword = password.getAsJsonPrimitive("askForOptionalPassword");
+
+                    response.setPublicPasswordEnforced(enforced.getAsBoolean());
+                    response.setAskForOptionalPassword(askForOptionalPassword.getAsBoolean());
+                }
+
                 final var isReSharingAllowed = filesSharing.getAsJsonPrimitive("resharing");
                 final var defaultPermission = filesSharing.getAsJsonPrimitive("default_permissions");
-
                 response.setDefaultPermission(defaultPermission.getAsInt());
-                response.setPublicPasswordEnforced(enforced.getAsBoolean());
-                response.setAskForOptionalPassword(askForOptionalPassword.getAsBoolean());
                 response.setReSharingAllowed(isReSharingAllowed.getAsBoolean());
             }
 

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
@@ -366,4 +366,79 @@ public class CapabilitiesDeserializerTest {
         assertFalse("Wrongly reporting that direct editing is supported", capabilities1.isDirectEditingAvailable());
 
     }
+
+
+    @Test
+    public void testSharingDisabled() {
+        //language=json
+        final String response = "" +
+                "{" +
+                "    \"version\": {" +
+                "        \"major\": 20," +
+                "        \"minor\": 0," +
+                "        \"micro\": 7," +
+                "        \"string\": \"20.0.7\"," +
+                "        \"edition\": \"\"," +
+                "        \"extendedSupport\": false" +
+                "    }," +
+                "    \"capabilities\": {" +
+                "        \"core\": {" +
+                "            \"pollinterval\": 60," +
+                "            \"webdav-root\": \"remote.php/webdav\"" +
+                "        }," +
+                "        \"notes\": {" +
+                "            \"api_version\": [" +
+                "                \"0.2\"," +
+                "                \"1.1\"" +
+                "            ]," +
+                "            \"version\": \"4.0.4\"" +
+                "        }," +
+                "        \"files_sharing\": {" +
+                "            \"api_enabled\": true," +
+                "            \"public\": {" +
+                "                \"enabled\": false," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": false" +
+                "                }," +
+                "                \"multiple_links\": true," +
+                "                \"expire_date_internal\": {" +
+                "                    \"enabled\": false" +
+                "                }," +
+                "                \"send_mail\": false," +
+                "                \"upload\": true," +
+                "                \"upload_files_drop\": true" +
+                "            }," +
+                "            \"resharing\": false," +
+                "            \"user\": {" +
+                "                \"send_mail\": false," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": true" +
+                "                }" +
+                "            }," +
+                "            \"group_sharing\": false," +
+                "            \"group\": {" +
+                "                \"enabled\": true," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": true" +
+                "                }" +
+                "            }," +
+                "            \"default_permissions\": 31," +
+                "            \"federation\": {" +
+                "                \"outgoing\": true," +
+                "                \"incoming\": true," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": true" +
+                "                }" +
+                "            }," +
+                "            \"sharee\": {" +
+                "                \"query_lookup_default\": false" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities = deserializer.deserialize(JsonParser.parseString(response), null, null);
+        assertNull(capabilities.getETag());
+        assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
+        assertFalse("Wrongly reporting that direct editing is supported", capabilities.isDirectEditingAvailable());
+    }
 }


### PR DESCRIPTION
The password object is optional and not sent in case sharing is disabled.

The added test fails before the code changes in the same way as the app does.