### PR TITLE
List item style

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainActivity.java
@@ -525,7 +525,7 @@ public class MainActivity extends LockedActivity implements NoteClickListener, A
             listView.setLayoutManager(gridLayoutManager);
             listView.addItemDecoration(new GridItemDecoration(adapter, spanCount,
                     getResources().getDimensionPixelSize(R.dimen.spacer_3x),
-                    getResources().getDimensionPixelSize(R.dimen.spacer_3x),
+                    getResources().getDimensionPixelSize(R.dimen.spacer_2x),
                     getResources().getDimensionPixelSize(R.dimen.spacer_3x),
                     getResources().getDimensionPixelSize(R.dimen.spacer_1x),
                     getResources().getDimensionPixelSize(R.dimen.spacer_activity_sides) + getResources().getDimensionPixelSize(R.dimen.spacer_1x)

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/ItemAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/ItemAdapter.java
@@ -52,7 +52,6 @@ import it.niedermann.owncloud.notes.shared.model.NoteClickListener;
 
 public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements Branded {
 
-
     public static final int TYPE_SECTION = 0;
     public static final int TYPE_NOTE_WITH_EXCERPT = 1;
     public static final int TYPE_NOTE_WITHOUT_EXCERPT = 2;
@@ -85,8 +84,8 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
         setHasStableIds(true);
     }
 
-
-    // FIXME this causes {@link it.niedermann.owncloud.notes.noteslist.items.list.NotesListViewItemTouchHelper} to not call clearView anymore → After marking a note as favorite, it stays yellow.
+    // FIXME this causes {@link it.niedermann.owncloud.notes.noteslist.items.list.NotesListViewItemTouchHelper} to
+    // not call clearView anymore → After marking a note as favorite, it stays yellow.
     @Override
     public long getItemId(int position) {
         return getItemViewType(position) == TYPE_SECTION
@@ -118,13 +117,31 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
                     return new SectionViewHolder(binding);
                 }
                 case TYPE_NOTE_ONLY_TITLE -> {
-                    ItemNotesListNoteItemGridOnlyTitleBinding binding = ItemNotesListNoteItemGridOnlyTitleBinding.inflate(inflater, parent, false);
+                    ItemNotesListNoteItemGridOnlyTitleBinding binding = ItemNotesListNoteItemGridOnlyTitleBinding
+                        .inflate(inflater, parent, false);
                     BrandingUtil.of(color, parent.getContext()).notes.themeCard(binding.noteCard);
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteTitle, ColorRole.ON_SURFACE
+                    );
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteModified, ColorRole.ON_SURFACE_VARIANT
+                    );
                     return new NoteViewGridHolderOnlyTitle(binding, noteClickListener, monospace, fontSize);
                 }
                 case TYPE_NOTE_WITH_EXCERPT, TYPE_NOTE_WITHOUT_EXCERPT -> {
-                    ItemNotesListNoteItemGridBinding binding = ItemNotesListNoteItemGridBinding.inflate(inflater, parent, false);
+                    ItemNotesListNoteItemGridBinding binding = ItemNotesListNoteItemGridBinding.inflate(
+                        inflater, parent, false
+                    );
                     BrandingUtil.of(color, parent.getContext()).notes.themeCard(binding.noteCard);
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteTitle, ColorRole.ON_SURFACE
+                    );
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteExcerpt, ColorRole.ON_SURFACE_VARIANT
+                    );
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteModified, ColorRole.ON_SURFACE_VARIANT
+                    );
                     return new NoteViewGridHolder(binding, noteClickListener, monospace, fontSize);
                 }
                 default -> {
@@ -139,8 +156,18 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
                     return new SectionViewHolder(binding);
                 }
                 case TYPE_NOTE_WITH_EXCERPT, TYPE_NOTE_ONLY_TITLE, TYPE_NOTE_WITHOUT_EXCERPT -> {
-                    ItemNotesListNoteItemWithExcerptBinding binding = ItemNotesListNoteItemWithExcerptBinding.inflate(inflater, parent, false);
+                    ItemNotesListNoteItemWithExcerptBinding binding = ItemNotesListNoteItemWithExcerptBinding
+                        .inflate(inflater, parent, false);
                     BrandingUtil.of(color, parent.getContext()).notes.themeCard(binding.noteCard);
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteTitle, ColorRole.ON_SURFACE
+                    );
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteExcerpt, ColorRole.ON_SURFACE_VARIANT
+                    );
+                    BrandingUtil.of(color, parent.getContext()).platform.colorTextView(
+                        binding.noteModified, ColorRole.ON_SURFACE_VARIANT
+                    );
                     return new NoteViewListHolder(binding, noteClickListener);
                 }
                 default -> {
@@ -166,18 +193,30 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> i
             case TYPE_SECTION ->
                     ((SectionViewHolder) holder).bind((SectionItem) itemList.get(position));
             case TYPE_NOTE_WITH_EXCERPT, TYPE_NOTE_WITHOUT_EXCERPT, TYPE_NOTE_ONLY_TITLE -> {
-                holder.itemView.findViewById(R.id.custom_checkbox).setVisibility(tracker != null && tracker.hasSelection() ? View.VISIBLE : View.GONE);
+                holder.itemView.findViewById(R.id.custom_checkbox).setVisibility(tracker != null &&
+                    tracker.hasSelection() ? View.VISIBLE : View.GONE);
                 holder.itemView.setSelected(isSelected);
                 if (isSelected) {
                     ((MaterialCardView) holder.itemView.findViewById(R.id.noteCard)).setStrokeWidth((int) holder.itemView.getResources().getDimension(R.dimen.card_stroke_width_selected));
-                    ((ImageView) holder.itemView.findViewById(R.id.custom_checkbox)).setImageDrawable(BrandingUtil.getInstance(holder.itemView.getContext()).platform.tintDrawable(holder.itemView.getContext(), R.drawable.ic_checkbox_marked, ColorRole.PRIMARY));
+                    ((ImageView) holder.itemView.findViewById(R.id.custom_checkbox)).setImageDrawable(
+                        BrandingUtil.getInstance(holder.itemView.getContext()).platform.tintDrawable(
+                            holder.itemView.getContext(), R.drawable.ic_checkbox_marked, ColorRole.PRIMARY)
+                    );
                 } else {
                     ((MaterialCardView) holder.itemView.findViewById(R.id.noteCard)).setStrokeWidth((int) holder.itemView.getResources().getDimension(R.dimen.card_stroke_width));
-                    ((ImageView) holder.itemView.findViewById(R.id.custom_checkbox)).setImageResource(R.drawable.ic_checkbox_blank_outline);
+                    ((ImageView) holder.itemView.findViewById(R.id.custom_checkbox)).setImageResource(
+                        R.drawable.ic_checkbox_blank_outline
+                    );
                 }
-                holder.itemView.findViewById(R.id.custom_checkbox).setVisibility(isMultiSelect ? View.VISIBLE : View.GONE);
-                holder.itemView.findViewById(R.id.noteFavorite).setVisibility(isMultiSelect ? View.GONE : View.VISIBLE);
-                ((NoteViewHolder) holder).bind(isSelected, (Note) itemList.get(position), showCategory, color, searchQuery);
+                holder.itemView.findViewById(R.id.custom_checkbox).setVisibility(
+                    isMultiSelect ? View.VISIBLE : View.GONE
+                );
+                holder.itemView.findViewById(R.id.noteFavorite).setVisibility(
+                    isMultiSelect ? View.GONE : View.VISIBLE
+                );
+                ((NoteViewHolder) holder).bind(
+                    isSelected, (Note) itemList.get(position), showCategory, color, searchQuery
+                );
             }
         }
     }

--- a/app/src/main/res/layout/item_notes_list_note_item_grid.xml
+++ b/app/src/main/res/layout/item_notes_list_note_item_grid.xml
@@ -2,7 +2,7 @@
 <!--
  ~ Nextcloud Notes - Android Client
  ~
- ~ SPDX-FileCopyrightText: 2020-2024 Nextcloud GmbH and Nextcloud contributors
+ ~ SPDX-FileCopyrightText: 2020-2025 Nextcloud GmbH and Nextcloud contributors
  ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -18,15 +18,14 @@
         android:id="@+id/wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/spacer_1x">
+        android:orientation="vertical">
 
         <TextView
             android:id="@+id/noteTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacer_2x"
-            android:layout_marginTop="@dimen/spacer_2x"
+            android:layout_marginTop="@dimen/spacer_list_card"
             android:layout_marginBottom="@dimen/spacer_1x"
             android:hyphenationFrequency="full"
             android:textAppearance="?attr/textAppearanceHeadline5"
@@ -34,17 +33,16 @@
             tools:maxLength="50"
             tools:text="@tools:sample/lorem/random" />
 
-
         <TextView
             android:id="@+id/noteExcerpt"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacer_2x"
+            android:layout_marginBottom="@dimen/spacer_1x"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@color/fg_default"
             tools:maxLength="200"
             tools:text="@tools:sample/lorem/random" />
-
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -61,7 +59,8 @@
                     android:layout_height="wrap_content"
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/menu_favorite"
-                    android:padding="@dimen/spacer_2x"
+                    android:paddingStart="@dimen/spacer_2x"
+                    android:paddingEnd="@dimen/spacer_list_card"
                     tools:src="@drawable/ic_star_yellow_24dp" />
 
                 <ImageView
@@ -72,7 +71,8 @@
                     android:clickable="false"
                     android:contentDescription="@null"
                     android:focusable="false"
-                    android:padding="@dimen/spacer_2x"
+                    android:paddingStart="@dimen/spacer_2x"
+                    android:paddingEnd="@dimen/spacer_list_card"
                     android:src="@drawable/ic_checkbox_blank_outline" />
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -80,8 +80,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical|end"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginEnd="4dp"
+                    android:layout_marginTop="@dimen/spacer_1x"
+                    android:layout_marginEnd="2dp"
                     android:baseline="14dp"
                     app:srcCompat="@drawable/ic_sync_blue_18dp" />
             </FrameLayout>
@@ -89,7 +89,9 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacer_2x"
+                android:layout_marginBottom="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/iconized_single_line_item_icon_size"
                 android:orientation="vertical">
 
                 <com.google.android.material.chip.Chip
@@ -120,8 +122,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="end"
-                    android:paddingStart="@dimen/spacer_1hx"
-                    android:paddingEnd="@dimen/spacer_2x"
+                    android:layout_marginEnd="@dimen/spacer_2x"
                     tools:text="27.11." />
 
             </LinearLayout>

--- a/app/src/main/res/layout/item_notes_list_note_item_grid_only_title.xml
+++ b/app/src/main/res/layout/item_notes_list_note_item_grid_only_title.xml
@@ -2,7 +2,7 @@
 <!--
  ~ Nextcloud Notes - Android Client
  ~
- ~ SPDX-FileCopyrightText: 2020-2024 Nextcloud GmbH and Nextcloud contributors
+ ~ SPDX-FileCopyrightText: 2020-2025 Nextcloud GmbH and Nextcloud contributors
  ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -15,30 +15,23 @@
     app:cardCornerRadius="@dimen/card_radius">
 
     <LinearLayout
+        android:id="@+id/wrapper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/spacer_2x"
         android:orientation="vertical">
 
-        <LinearLayout
-            android:id="@+id/wrapper"
+        <TextView
+            android:id="@+id/noteTitle"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/noteTitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/spacer_2x"
-                android:layout_marginTop="@dimen/spacer_2x"
-                android:hyphenationFrequency="full"
-                android:textAppearance="?attr/textAppearanceHeadline5"
-                android:textColor="@color/fg_default"
-                tools:maxLength="50"
-                tools:text="@tools:sample/lorem/random" />
-
-        </LinearLayout>
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/spacer_2x"
+            android:layout_marginTop="@dimen/spacer_list_card"
+            android:layout_marginBottom="@dimen/spacer_1x"
+            android:hyphenationFrequency="full"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:textColor="@color/fg_default"
+            tools:maxLength="50"
+            tools:text="@tools:sample/lorem/random" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -55,17 +48,20 @@
                     android:layout_height="wrap_content"
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/menu_favorite"
-                    android:padding="@dimen/spacer_2x"
+                    android:paddingStart="@dimen/spacer_2x"
+                    android:paddingEnd="@dimen/spacer_list_card"
                     tools:src="@drawable/ic_star_yellow_24dp" />
 
                 <ImageView
                     android:id="@+id/custom_checkbox"
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top"
                     android:clickable="false"
                     android:contentDescription="@null"
                     android:focusable="false"
-                    android:padding="@dimen/spacer_2x"
+                    android:paddingStart="@dimen/spacer_2x"
+                    android:paddingEnd="@dimen/spacer_list_card"
                     android:src="@drawable/ic_checkbox_blank_outline" />
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -73,8 +69,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical|end"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginEnd="4dp"
+                    android:layout_marginTop="@dimen/spacer_1x"
+                    android:layout_marginEnd="2dp"
                     android:baseline="14dp"
                     app:srcCompat="@drawable/ic_sync_blue_18dp" />
             </FrameLayout>
@@ -82,7 +78,9 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacer_2x"
+                android:layout_marginBottom="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/iconized_single_line_item_icon_size"
                 android:orientation="vertical">
 
                 <com.google.android.material.chip.Chip
@@ -113,8 +111,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="end"
-                    android:paddingStart="@dimen/spacer_1hx"
-                    android:paddingEnd="@dimen/spacer_2x"
+                    android:layout_marginEnd="@dimen/spacer_2x"
                     tools:text="27.11." />
 
             </LinearLayout>


### PR DESCRIPTION
The differences between current and M3 might be hard to spot...

* M3 has a minimal shade of primary mixed in, contrary to "current"
* M2 is simply shades of grey and they way we for now styled list items in the files and Talk apps

➡️ Personally I'd simply go with M3, it is the current standard _and_ is also close to the current look.

|current|M3|M2/Nextcloud|
|---|---|---|
|<img width="1080" height="2376" alt="current" src="https://github.com/user-attachments/assets/c9f4d5fd-abdc-4b68-8f1d-cb65336c0520" />|<img width="1080" height="2376" alt="M3" src="https://github.com/user-attachments/assets/39e80bf6-0348-4e88-916b-e4731814156f" />|<img width="1080" height="2376" alt="Nextcloud" src="https://github.com/user-attachments/assets/310b9c58-9739-4f55-96a7-001e2caae37f" />|
