### PR TITLE
Fix SQLiteBlobTooBigException in note sync

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -521,7 +521,8 @@ public class NotesRepository {
     public Note addNote(long accountId, @NonNull Note note) {
         note.setAccountId(accountId);
         note.setExcerpt(generateNoteExcerpt(note.getContent(), note.getTitle()));
-        return db.getNoteDao().getNoteById(db.getNoteDao().addNote(note));
+        note.setId(db.getNoteDao().addNote(note));
+        return note;
     }
 
     @MainThread


### PR DESCRIPTION
Fixes #3148

The addNote() method was inserting notes and then immediately calling getNoteById() to fetch them back. With large content, this redundant fetch was triggering SQLiteBlobTooBigException.

Just set the ID on the note object directly and return it. No need for the extra database call.

## Screenshots
N/A - backend fix only

## Testing
- [x] Tested with notes of various sizes, including ones that would have triggered the exception
- [x] Verified notes insert correctly with proper ID
- [x] Sync operations work normally