### PR TITLE
fix: harden capabilities deserialization when sharing fields are missing

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializer.java
@@ -49,93 +49,151 @@ public class CapabilitiesDeserializer implements JsonDeserializer<Capabilities> 
     public Capabilities deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         final var response = new Capabilities();
         final var data = json.getAsJsonObject();
-        if (data.has(VERSION)) {
-            final var version = data.getAsJsonObject(VERSION);
-            final var nextcloudMajorVersion = version.get("major");
-            response.setNextcloudMajorVersion(String.valueOf(nextcloudMajorVersion));
 
-            final var nextcloudMinorVersion = version.get("minor");
-            response.setNextcloudMinorVersion(String.valueOf(nextcloudMinorVersion));
+        deserializeVersion(data, response);
 
-
-            final var nextcloudMicroVersion = version.get("micro");
-            response.setNextcloudMicroVersion(String.valueOf(nextcloudMicroVersion));
+        if (!data.has(CAPABILITIES)) {
+            return response;
         }
 
-        if (data.has(CAPABILITIES)) {
-            final var capabilities = data.getAsJsonObject(CAPABILITIES);
+        final var capabilities = data.getAsJsonObject(CAPABILITIES);
 
-            if (capabilities.has(CAPABILITIES_FILES_SHARING)) {
-                final var filesSharing = capabilities.getAsJsonObject(CAPABILITIES_FILES_SHARING);
-                final var federation = filesSharing.getAsJsonObject("federation");
-                final var outgoing = federation.get("outgoing");
+        deserializeFilesSharing(capabilities, response);
+        deserializeNotes(capabilities, response);
+        deserializeTheming(capabilities, response);
+        deserializeDirectEditing(capabilities, response);
+        deserializeUserStatus(capabilities, response);
 
-                response.setFederationShare(outgoing.getAsBoolean());
-
-                final var publicObject = filesSharing.getAsJsonObject("public");
-                if (publicObject.has("password")) {
-                    final var password = publicObject.getAsJsonObject("password");
-                    final var enforced = password.getAsJsonPrimitive("enforced");
-                    final var askForOptionalPassword = password.getAsJsonPrimitive("askForOptionalPassword");
-
-                    response.setPublicPasswordEnforced(enforced.getAsBoolean());
-                    response.setAskForOptionalPassword(askForOptionalPassword.getAsBoolean());
-                }
-
-                final var isReSharingAllowed = filesSharing.getAsJsonPrimitive("resharing");
-                final var defaultPermission = filesSharing.getAsJsonPrimitive("default_permissions");
-                response.setDefaultPermission(defaultPermission.getAsInt());
-                response.setReSharingAllowed(isReSharingAllowed.getAsBoolean());
-            }
-
-            if (capabilities.has(CAPABILITIES_NOTES)) {
-                final var notes = capabilities.getAsJsonObject(CAPABILITIES_NOTES);
-                if (notes.has(CAPABILITIES_NOTES_API_VERSION)) {
-                    response.setApiVersion(notes.get(CAPABILITIES_NOTES_API_VERSION).toString());
-                }
-            }
-            if (capabilities.has(CAPABILITIES_THEMING)) {
-                final var theming = capabilities.getAsJsonObject(CAPABILITIES_THEMING);
-                if (theming.has(CAPABILITIES_THEMING_COLOR)) {
-                    try {
-                        response.setColor(Color.parseColor(ColorUtil.formatColorToParsableHexString(theming.get(CAPABILITIES_THEMING_COLOR).getAsString())));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-                if (theming.has(CAPABILITIES_THEMING_COLOR_TEXT)) {
-                    try {
-                        response.setTextColor(Color.parseColor(ColorUtil.formatColorToParsableHexString(theming.get(CAPABILITIES_THEMING_COLOR_TEXT).getAsString())));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-            response.setDirectEditingAvailable(hasDirectEditingCapability(capabilities));
-
-            if (capabilities.has(CAPABILITIES_USER_STATUS)) {
-                final var userStatus = capabilities.getAsJsonObject(CAPABILITIES_USER_STATUS);
-                if (userStatus.has(CAPABILITIES_SUPPORTS_BUSY)) {
-                    final var userStatusSupportsBusy = userStatus.getAsJsonPrimitive(CAPABILITIES_SUPPORTS_BUSY);
-                    if (userStatusSupportsBusy != null) {
-                        response.setUserStatusSupportsBusy(userStatusSupportsBusy.getAsBoolean());
-                    }
-                }
-            }
-        }
         return response;
     }
 
-    private boolean hasDirectEditingCapability(final JsonObject capabilities) {
-        if (capabilities.has(CAPABILITIES_FILES)) {
-            final var files = capabilities.getAsJsonObject(CAPABILITIES_FILES);
-            if (files.has(CAPABILITIES_FILES_DIRECT_EDITING)) {
-                final var directEditing = files.getAsJsonObject(CAPABILITIES_FILES_DIRECT_EDITING);
-                if (directEditing.has(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID)) {
-                    return directEditing.get(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID).getAsBoolean();
+    private void deserializeVersion(final JsonObject data, final Capabilities response) {
+        if (!data.has(VERSION)) {
+            return;
+        }
+
+        final var version = data.getAsJsonObject(VERSION);
+
+        if (version.has("major")) {
+            response.setNextcloudMajorVersion(String.valueOf(version.get("major")));
+        }
+        if (version.has("minor")) {
+            response.setNextcloudMinorVersion(String.valueOf(version.get("minor")));
+        }
+        if (version.has("micro")) {
+            response.setNextcloudMicroVersion(String.valueOf(version.get("micro")));
+        }
+    }
+
+    private void deserializeFilesSharing(final JsonObject capabilities, final Capabilities response) {
+        if (!capabilities.has(CAPABILITIES_FILES_SHARING)) {
+            return;
+        }
+
+        final var filesSharing = capabilities.getAsJsonObject(CAPABILITIES_FILES_SHARING);
+
+        if (filesSharing.has("federation")) {
+            final var federation = filesSharing.getAsJsonObject("federation");
+            if (federation.has("outgoing")) {
+                response.setFederationShare(federation.get("outgoing").getAsBoolean());
+            }
+        }
+
+        if (filesSharing.has("api_enabled")) {
+            final var shareApiEnabled = filesSharing.get("api_enabled");
+            if (!shareApiEnabled.getAsBoolean()) {
+                return;
+            }
+        }
+
+        if (filesSharing.has("public")) {
+            final var publicObject = filesSharing.getAsJsonObject("public");
+            if (publicObject.has("password")) {
+                final var password = publicObject.getAsJsonObject("password");
+                if (password.has("enforced")) {
+                    response.setPublicPasswordEnforced(password.getAsJsonPrimitive("enforced").getAsBoolean());
+                }
+                if (password.has("askForOptionalPassword")) {
+                    response.setAskForOptionalPassword(password.getAsJsonPrimitive("askForOptionalPassword").getAsBoolean());
                 }
             }
         }
-        return false;
+
+        if (filesSharing.has("resharing")) {
+            response.setReSharingAllowed(filesSharing.getAsJsonPrimitive("resharing").getAsBoolean());
+        }
+
+        if (filesSharing.has("default_permissions")) {
+            response.setDefaultPermission(filesSharing.getAsJsonPrimitive("default_permissions").getAsInt());
+        }
+    }
+
+    private void deserializeNotes(final JsonObject capabilities, final Capabilities response) {
+        if (!capabilities.has(CAPABILITIES_NOTES)) {
+            return;
+        }
+
+        final var notes = capabilities.getAsJsonObject(CAPABILITIES_NOTES);
+        if (notes.has(CAPABILITIES_NOTES_API_VERSION)) {
+            response.setApiVersion(notes.get(CAPABILITIES_NOTES_API_VERSION).toString());
+        }
+    }
+
+    private void deserializeTheming(final JsonObject capabilities, final Capabilities response) {
+        if (!capabilities.has(CAPABILITIES_THEMING)) {
+            return;
+        }
+
+        final var theming = capabilities.getAsJsonObject(CAPABILITIES_THEMING);
+        if (theming.has(CAPABILITIES_THEMING_COLOR)) {
+            try {
+                response.setColor(Color.parseColor(ColorUtil.formatColorToParsableHexString(
+                        theming.get(CAPABILITIES_THEMING_COLOR).getAsString()
+                )));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (theming.has(CAPABILITIES_THEMING_COLOR_TEXT)) {
+            try {
+                response.setTextColor(Color.parseColor(ColorUtil.formatColorToParsableHexString(
+                        theming.get(CAPABILITIES_THEMING_COLOR_TEXT).getAsString()
+                )));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void deserializeUserStatus(final JsonObject capabilities, final Capabilities response) {
+        if (!capabilities.has(CAPABILITIES_USER_STATUS)) {
+            return;
+        }
+
+        final var userStatus = capabilities.getAsJsonObject(CAPABILITIES_USER_STATUS);
+        if (userStatus.has(CAPABILITIES_SUPPORTS_BUSY)) {
+            final var userStatusSupportsBusy = userStatus.getAsJsonPrimitive(CAPABILITIES_SUPPORTS_BUSY);
+            if (userStatusSupportsBusy != null) {
+                response.setUserStatusSupportsBusy(userStatusSupportsBusy.getAsBoolean());
+            }
+        }
+    }
+
+    private void deserializeDirectEditing(final JsonObject capabilities, final Capabilities response) {
+        if (!capabilities.has(CAPABILITIES_FILES)) {
+            response.setDirectEditingAvailable(false);
+            return;
+        }
+
+        final var files = capabilities.getAsJsonObject(CAPABILITIES_FILES);
+        if (files.has(CAPABILITIES_FILES_DIRECT_EDITING)) {
+            final var directEditing = files.getAsJsonObject(CAPABILITIES_FILES_DIRECT_EDITING);
+            if (directEditing.has(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID)) {
+                response.setDirectEditingAvailable(
+                        directEditing.get(CAPABILITIES_FILES_DIRECT_EDITING_SUPPORTS_FILE_ID).getAsBoolean()
+                );
+            }
+        }
     }
 }

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/sync/CapabilitiesDeserializerTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import android.graphics.Color;
 
 import com.google.gson.JsonParser;
+import com.owncloud.android.lib.resources.shares.OCShare;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -116,7 +117,6 @@ public class CapabilitiesDeserializerTest {
         assertEquals(Color.parseColor("#1E4164"), capabilities.getColor());
         assertEquals(Color.parseColor("#ffffff"), capabilities.getTextColor());
     }
-
 
     @Test
     public void testRealisticSample() {
@@ -314,7 +314,6 @@ public class CapabilitiesDeserializerTest {
         assertFalse("Wrongly reporting that direct editing is supported", capabilities.isDirectEditingAvailable());
     }
 
-
     @Test
     public void testDirectEditing() {
         //language=json
@@ -364,12 +363,10 @@ public class CapabilitiesDeserializerTest {
                 "}";
         final var capabilities1 = deserializer.deserialize(JsonParser.parseString(responseNotOk), null, null);
         assertFalse("Wrongly reporting that direct editing is supported", capabilities1.isDirectEditingAvailable());
-
     }
 
-
     @Test
-    public void testSharingDisabled() {
+    public void testPublicSharingDisabledWithoutPassword() {
         //language=json
         final String response = "" +
                 "{" +
@@ -382,10 +379,6 @@ public class CapabilitiesDeserializerTest {
                 "        \"extendedSupport\": false" +
                 "    }," +
                 "    \"capabilities\": {" +
-                "        \"core\": {" +
-                "            \"pollinterval\": 60," +
-                "            \"webdav-root\": \"remote.php/webdav\"" +
-                "        }," +
                 "        \"notes\": {" +
                 "            \"api_version\": [" +
                 "                \"0.2\"," +
@@ -437,8 +430,134 @@ public class CapabilitiesDeserializerTest {
                 "    }" +
                 "}";
         final var capabilities = deserializer.deserialize(JsonParser.parseString(response), null, null);
-        assertNull(capabilities.getETag());
         assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
-        assertFalse("Wrongly reporting that direct editing is supported", capabilities.isDirectEditingAvailable());
+        assertFalse(capabilities.getPublicPasswordEnforced());
+        assertFalse(capabilities.getAskForOptionalPassword());
+        assertFalse(capabilities.isReSharingAllowed());
+        assertEquals(31, capabilities.getDefaultPermission());
+        assertTrue(capabilities.getFederationShare());
+    }
+
+    @Test
+    public void testShareApiDisabledKeepsDefaults() {
+        //language=json
+        final String response = "" +
+                "{" +
+                "    \"version\": {" +
+                "        \"major\": 31," +
+                "        \"minor\": 0," +
+                "        \"micro\": 8" +
+                "    }," +
+                "    \"capabilities\": {" +
+                "        \"notes\": {" +
+                "            \"api_version\": [" +
+                "                \"0.2\"," +
+                "                \"1.1\"" +
+                "            ]" +
+                "        }," +
+                "        \"files_sharing\": {" +
+                "            \"api_enabled\": false," +
+                "            \"public\": {" +
+                "                \"enabled\": false" +
+                "            }," +
+                "            \"user\": {" +
+                "                \"send_mail\": false" +
+                "            }," +
+                "            \"resharing\": false," +
+                "            \"federation\": {" +
+                "                \"outgoing\": true," +
+                "                \"incoming\": true," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": true" +
+                "                }" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities = deserializer.deserialize(JsonParser.parseString(response), null, null);
+        assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
+        assertTrue(capabilities.getFederationShare());
+        assertFalse(capabilities.getPublicPasswordEnforced());
+        assertFalse(capabilities.getAskForOptionalPassword());
+        assertFalse(capabilities.isReSharingAllowed());
+        assertEquals(OCShare.NO_PERMISSION, capabilities.getDefaultPermission());
+    }
+
+    @Test
+    public void testMissingDefaultPermissionsKeepsDefault() {
+        //language=json
+        final String response = "" +
+                "{" +
+                "    \"version\": {" +
+                "        \"major\": 33," +
+                "        \"minor\": 0," +
+                "        \"micro\": 2" +
+                "    }," +
+                "    \"capabilities\": {" +
+                "        \"notes\": {" +
+                "            \"api_version\": [" +
+                "                \"0.2\"," +
+                "                \"1.1\"" +
+                "            ]" +
+                "        }," +
+                "        \"files_sharing\": {" +
+                "            \"api_enabled\": true," +
+                "            \"public\": {" +
+                "                \"enabled\": false" +
+                "            }," +
+                "            \"resharing\": false," +
+                "            \"federation\": {" +
+                "                \"outgoing\": true," +
+                "                \"incoming\": true," +
+                "                \"expire_date\": {" +
+                "                    \"enabled\": true" +
+                "                }" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities = deserializer.deserialize(JsonParser.parseString(response), null, null);
+        assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
+        assertTrue(capabilities.getFederationShare());
+        assertFalse(capabilities.isReSharingAllowed());
+        assertEquals(OCShare.NO_PERMISSION, capabilities.getDefaultPermission());
+    }
+
+    @Test
+    public void testMissingFederationKeepsDefault() {
+        //language=json
+        final String response = "" +
+                "{" +
+                "    \"version\": {" +
+                "        \"major\": 33," +
+                "        \"minor\": 0," +
+                "        \"micro\": 2" +
+                "    }," +
+                "    \"capabilities\": {" +
+                "        \"notes\": {" +
+                "            \"api_version\": [" +
+                "                \"0.2\"," +
+                "                \"1.1\"" +
+                "            ]" +
+                "        }," +
+                "        \"files_sharing\": {" +
+                "            \"api_enabled\": true," +
+                "            \"public\": {" +
+                "                \"enabled\": true," +
+                "                \"password\": {" +
+                "                    \"enforced\": false," +
+                "                    \"askForOptionalPassword\": false" +
+                "                }" +
+                "            }," +
+                "            \"resharing\": true," +
+                "            \"default_permissions\": 31" +
+                "        }" +
+                "    }" +
+                "}";
+        final var capabilities = deserializer.deserialize(JsonParser.parseString(response), null, null);
+        assertEquals("[\"0.2\",\"1.1\"]", capabilities.getApiVersion());
+        assertFalse(capabilities.getFederationShare());
+        assertTrue(capabilities.isReSharingAllowed());
+        assertEquals(31, capabilities.getDefaultPermission());
     }
 }


### PR DESCRIPTION
## Summary

Refactor `CapabilitiesDeserializer` to safely handle partial `files_sharing` capability payloads, especially when Share API or public sharing is disabled. Previously merged PR #2803 helped, but did not cover all edge cases.

## Changes

* split capability parsing into smaller helper methods
* use `api_enabled` as a gate for share-specific parsing
* avoid assuming optional` files_sharing` fields are always present
* preserve model defaults when fields like `default_permissions` or `public.password` are missing
* rename/update the misleading sharing test
* add regression tests for:
  - Share API disabled responses
  - missing `default_permissions`
  - missing `ederation`
  - public sharing disabled without password fields

## Why

The server can legitimately omit parts of `files_sharing` depending on configuration. The previous deserializer assumed those fields always existed, which could cause crashes during first-time account setup when Share API was disabled or when certain sharing options were turned off.

## Result

The app now tolerates partial sharing capability responses and falls back to the existing defaults in `Capabilities` instead of crashing.

Closes #2815 
Closes #3165 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [x] 🧪 Tests written, or not not needed
