### PR TITLE
fix(branding): refresh BrandingUtil instance when color changes

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
@@ -70,6 +70,10 @@ public class NotesApplication extends Application {
         return brandingUtil;
     }
 
+    public static void reloadBrandingUtil(Context context) {
+        brandingUtil = BrandingUtil.getInstance(context.getApplicationContext());
+    }
+
     public static void setAppTheme(DarkModeSetting setting) {
         AppCompatDelegate.setDefaultNightMode(setting.getModeId());
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/branding/BrandingUtil.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import it.niedermann.android.sharedpreferences.SharedPreferenceIntLiveData;
+import it.niedermann.owncloud.notes.NotesApplication;
 import it.niedermann.owncloud.notes.R;
 
 public class BrandingUtil extends ViewThemeUtilsBase {
@@ -88,9 +89,9 @@ public class BrandingUtil extends ViewThemeUtilsBase {
         Log.v(TAG, "--- Write: shared_preference_theme_main" + " | " + color);
         editor.putInt(pref_key_branding_main, color);
         editor.apply();
-        if (context instanceof BrandedActivity) {
-            if (color != previousMainColor) {
-                final var activity = (BrandedActivity) context;
+        if (color != previousMainColor) {
+            NotesApplication.reloadBrandingUtil(context);
+            if (context instanceof BrandedActivity activity) {
                 activity.runOnUiThread(() -> ActivityCompat.recreate(activity));
             }
         }


### PR DESCRIPTION
## Purpose / Description
Refresh BrandingUtil instance when color changes (switch account to another having diffrent theme color)

## Fixes
* Fixes #2863 