### PR TITLE
Reorg edit Buttons

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -375,6 +375,9 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
                 note.setScrollY(scrollY);
             }
             onScroll(scrollY, oldScrollY);
+            if (listener != null) {
+                listener.onScroll(scrollY, oldScrollY);
+            }
         });
     }
 
@@ -538,5 +541,9 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
         void onNoteUpdated(Note note);
 
         void changeMode(@NonNull Mode mode, boolean reloadNote);
+
+        void onScroll(int scrollY, int oldScrollY);
+
+        void onSearchActive(boolean active);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -266,24 +266,27 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         binding.fabPreview.hide();
 
         final var margin1x = getResources().getDimensionPixelSize(R.dimen.spacer_2x);
-        final var params = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabEdit.getLayoutParams();
+        final var paramsEdit = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabEdit.getLayoutParams();
+        final var paramsPreview = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabPreview.getLayoutParams();
 
         if (fragment instanceof NotePreviewFragment && !(fragment instanceof NoteReadonlyFragment)) {
             if (directEditEnabled) {
                 binding.fabDirectEdit.show();
                 binding.fabEdit.show();
-                params.setMargins(margin1x, margin1x, margin1x, (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 88, getResources().getDisplayMetrics()));
+                paramsEdit.setMargins(margin1x, margin1x, margin1x, (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 88, getResources().getDisplayMetrics()));
             } else {
                 binding.fabEdit.show();
-                params.setMargins(margin1x, margin1x, margin1x, margin1x);
+                paramsEdit.setMargins(margin1x, margin1x, margin1x, margin1x);
             }
         } else if (fragment instanceof NoteEditFragment || fragment instanceof NoteDirectEditFragment) {
             binding.fabPreview.show();
+            if (fragment instanceof NoteDirectEditFragment) {
+                paramsPreview.setMargins(margin1x, margin1x, margin1x, (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 64, getResources().getDisplayMetrics()));
+            } else {
+                paramsPreview.setMargins(margin1x, margin1x, margin1x, margin1x);
+            }
         }
-        binding.fabEdit.setLayoutParams(params);
-
-        final var paramsPreview = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabPreview.getLayoutParams();
-        paramsPreview.setMargins(margin1x, margin1x, margin1x, margin1x);
+        binding.fabEdit.setLayoutParams(paramsEdit);
         binding.fabPreview.setLayoutParams(paramsPreview);
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -28,6 +29,7 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
@@ -50,6 +52,7 @@ import it.niedermann.owncloud.notes.persistence.NotesRepository;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.NavigationCategory;
+import it.niedermann.owncloud.notes.shared.util.ExtendedFabUtil;
 import it.niedermann.owncloud.notes.shared.util.NoteUtil;
 import it.niedermann.owncloud.notes.shared.util.ShareUtil;
 
@@ -109,6 +112,7 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         setSupportActionBar(binding.toolbar);
         binding.toolbar.setOnClickListener((v) -> fragment.showEditTitleDialog());
         setImeInsets();
+        setupFabs();
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
@@ -245,8 +249,58 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         } else {
             binding.toolbar.setVisibility(View.VISIBLE);
         }
+        updateFabVisibility();
     }
 
+    private void setupFabs() {
+        binding.fabEdit.setOnClickListener(v -> changeMode(Mode.EDIT, false));
+        binding.fabDirectEdit.setOnClickListener(v -> changeMode(Mode.DIRECT_EDIT, false));
+        binding.fabPreview.setOnClickListener(v -> changeMode(Mode.PREVIEW, false));
+    }
+
+    private void updateFabVisibility() {
+        final boolean directEditEnabled = isDirectEditEnabled();
+
+        binding.fabEdit.hide();
+        binding.fabDirectEdit.hide();
+        binding.fabPreview.hide();
+
+        final var margin1x = getResources().getDimensionPixelSize(R.dimen.spacer_2x);
+        final var params = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabEdit.getLayoutParams();
+
+        if (fragment instanceof NotePreviewFragment && !(fragment instanceof NoteReadonlyFragment)) {
+            if (directEditEnabled) {
+                binding.fabDirectEdit.show();
+                binding.fabEdit.show();
+                params.setMargins(margin1x, margin1x, margin1x, (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 88, getResources().getDisplayMetrics()));
+            } else {
+                binding.fabEdit.show();
+                params.setMargins(margin1x, margin1x, margin1x, margin1x);
+            }
+        } else if (fragment instanceof NoteEditFragment || fragment instanceof NoteDirectEditFragment) {
+            binding.fabPreview.show();
+        }
+        binding.fabEdit.setLayoutParams(params);
+
+        final var paramsPreview = (androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams) binding.fabPreview.getLayoutParams();
+        paramsPreview.setMargins(margin1x, margin1x, margin1x, margin1x);
+        binding.fabPreview.setLayoutParams(paramsPreview);
+    }
+
+    private boolean isDirectEditEnabled() {
+        final long accountId = getAccountId();
+        final Account account = repo.getAccountById(accountId);
+        final boolean directEditRemotelyAvailable = account != null && account.isDirectEditingAvailable();
+        final var preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        return preferences.getBoolean(getString(R.string.pref_key_enable_direct_edit), true) && directEditRemotelyAvailable;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.menu_preview).setVisible(false);
+        menu.findItem(R.id.menu_edit).setVisible(false);
+        return super.onPrepareOptionsMenu(menu);
+    }
 
     /**
      * Returns the preferred mode for the account. If the mode is "remember last" the last mode is returned.
@@ -450,11 +504,51 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
     }
 
     @Override
+    public void onSearchActive(boolean active) {
+        if (active) {
+            binding.fabEdit.hide();
+            binding.fabDirectEdit.hide();
+            binding.fabPreview.hide();
+        } else {
+            updateFabVisibility();
+        }
+    }
+
+    @Override
+    public void onScroll(int scrollY, int oldScrollY) {
+        if (isFabActive(binding.fabEdit)) {
+            ExtendedFabUtil.toggleVisibilityOnScroll(binding.fabEdit, scrollY, oldScrollY);
+        }
+        if (isFabActive(binding.fabDirectEdit)) {
+            ExtendedFabUtil.toggleVisibilityOnScroll(binding.fabDirectEdit, scrollY, oldScrollY);
+        }
+        if (isFabActive(binding.fabPreview)) {
+            ExtendedFabUtil.toggleVisibilityOnScroll(binding.fabPreview, scrollY, oldScrollY);
+        }
+    }
+
+    private boolean isFabActive(FloatingActionButton fab) {
+        final boolean directEditEnabled = isDirectEditEnabled();
+
+        if (fab == binding.fabEdit) {
+            return (fragment instanceof NotePreviewFragment && !(fragment instanceof NoteReadonlyFragment));
+        } else if (fab == binding.fabDirectEdit) {
+            return (fragment instanceof NotePreviewFragment && directEditEnabled);
+        } else if (fab == binding.fabPreview) {
+            return (fragment instanceof NoteEditFragment || fragment instanceof NoteDirectEditFragment);
+        }
+        return false;
+    }
+
+    @Override
     public void applyBrand(int color) {
         final var util = BrandingUtil.of(color, this);
         util.platform.themeStatusBar(this);
         util.material.themeToolbar(binding.toolbar);
         util.platform.colorViewBackground(getWindow().getDecorView());
         util.platform.colorViewBackground(binding.getRoot());
+        util.material.themeFAB(binding.fabEdit);
+        util.material.themeFAB(binding.fabDirectEdit);
+        util.material.themeFAB(binding.fabPreview);
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -43,7 +43,6 @@ import it.niedermann.owncloud.notes.persistence.entity.Note
 import it.niedermann.owncloud.notes.persistence.sync.NotesAPI
 import it.niedermann.owncloud.notes.shared.model.ApiVersion
 import it.niedermann.owncloud.notes.shared.model.ISyncCallback
-import it.niedermann.owncloud.notes.shared.util.ExtendedFabUtil
 import it.niedermann.owncloud.notes.shared.util.rx.DisposableSet
 import okio.IOException
 import java.util.concurrent.TimeUnit
@@ -84,35 +83,24 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
     ): View? {
         Log.d(TAG, "onCreateView() called")
         _binding = FragmentNoteDirectEditBinding.inflate(inflater, container, false)
-        setupFab()
+        setupScrollDetection()
         prepareWebView()
         return binding?.root
     }
 
-    @SuppressLint("ClickableViewAccessibility") // touch listener only for UI purposes, no need to handle click
-    private fun setupFab() {
-        binding?.run {
-            plainEditingFab.isExtended = false
-            ExtendedFabUtil.toggleExtendedOnLongClick(plainEditingFab)
-
-            // manually detect scroll as we can't get it from the webview (maybe with custom JS?)
-            noteWebview.setOnTouchListener { _, event ->
-                when (event.action) {
-                    MotionEvent.ACTION_DOWN -> {
-                        scrollStart = event.y.toInt()
-                    }
-                    MotionEvent.ACTION_UP -> {
-                        val scrollEnd = event.y.toInt()
-                        ExtendedFabUtil.toggleVisibilityOnScroll(
-                            plainEditingFab,
-                            scrollStart,
-                            scrollEnd,
-                        )
-                    }
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setupScrollDetection() {
+        binding?.noteWebview?.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    scrollStart = event.y.toInt()
                 }
-                return@setOnTouchListener false
+                MotionEvent.ACTION_UP -> {
+                    val scrollEnd = event.y.toInt()
+                    listener?.onScroll(scrollStart, scrollEnd)
+                }
             }
-            plainEditingFab.setOnClickListener { switchToPlainEdit() }
+            return@setOnTouchListener false
         }
     }
 
@@ -218,7 +206,7 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
     private fun handleLoadError() {
         binding?.run {
             val snackbar = BrandedSnackbar.make(
-                plainEditingFab,
+                root,
                 getString(R.string.direct_editing_error),
                 Snackbar.LENGTH_INDEFINITE,
             )
@@ -328,7 +316,6 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
         val util = BrandingUtil.of(color, requireContext())
 
         binding?.run {
-            util.material.themeExtendedFAB(plainEditingFab)
             util.platform.colorCircularProgressBar(progress, ColorRole.PRIMARY)
         }
     }
@@ -398,7 +385,6 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
             binding?.run {
                 progress.isVisible = loading
                 noteWebview.isVisible = !loading
-                plainEditingFab.isVisible = !loading
             }
         }
     }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -31,7 +31,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -82,8 +81,6 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        menu.findItem(R.id.menu_edit).setVisible(false);
-        menu.findItem(R.id.menu_preview).setVisible(true);
     }
 
     @Override
@@ -112,16 +109,6 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     @Override
     protected FloatingActionButton getSearchPrevButton() {
         return binding.searchPrev;
-    }
-
-    @Override
-    protected @NonNull ExtendedFloatingActionButton getDirectEditingButton() {
-        return binding.directEditing;
-    }
-
-    protected ExtendedFloatingActionButton getNormalEditButton() {
-        // the edit fragment does not have a button
-        return null;
     }
 
     @Nullable

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -29,7 +29,6 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener;
 
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -57,12 +56,6 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        menu.findItem(R.id.menu_edit).setVisible(true);
-        if(getNormalEditButton().getVisibility() == View.VISIBLE) {
-            menu.findItem(R.id.menu_edit).setVisible(false);
-        }
-
-        menu.findItem(R.id.menu_preview).setVisible(false);
     }
 
     @Override
@@ -89,16 +82,6 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Override
     protected FloatingActionButton getSearchPrevButton() {
         return binding.searchPrev;
-    }
-
-    @Override
-    protected @NonNull ExtendedFloatingActionButton getDirectEditingButton() {
-        return binding.directEditing;
-    }
-
-    @Override
-    protected ExtendedFloatingActionButton getNormalEditButton() {
-        return binding.edit;
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -23,7 +23,6 @@ import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
@@ -35,7 +34,6 @@ import java.util.regex.Pattern;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.branding.BrandingUtil;
 import it.niedermann.owncloud.notes.persistence.entity.Account;
-import it.niedermann.owncloud.notes.shared.util.ExtendedFabUtil;
 
 public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
 
@@ -50,7 +48,6 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     private static final int delay = 50; // If the search string does not change after $delay ms, then the search task starts.
     private static final int shortStringDelay = 200; // A longer delay for short search strings.
     private static final int shortStringSize = 3; // The maximum length of a short search string.
-    private boolean directEditRemotelyAvailable = false; // avoid using this directly, instead use: isDirectEditEnabled()
 
     @ColorInt
     private int color;
@@ -75,62 +72,11 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     @Override
     protected void onScroll(int scrollY, int oldScrollY) {
         super.onScroll(scrollY, oldScrollY);
-        if (isDirectEditEnabled()) {
-            // only show FAB if search is not active
-            if (getSearchNextButton() == null || getSearchNextButton().getVisibility() != View.VISIBLE) {
-                final ExtendedFloatingActionButton directFab = getDirectEditingButton();
-                ExtendedFabUtil.toggleVisibilityOnScroll(directFab, scrollY, oldScrollY);
-            }
-        }
     }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        checkDirectEditingAvailable();
-        if (isDirectEditEnabled()) {
-            ExtendedFloatingActionButton edit = getNormalEditButton();
-            if (edit != null) edit.setVisibility(View.GONE);
-            final ExtendedFloatingActionButton directEditingButton = getDirectEditingButton();
-            directEditingButton.setExtended(false);
-            directEditingButton.setVisibility(View.VISIBLE);
-            ExtendedFabUtil.toggleExtendedOnLongClick(directEditingButton);
-            directEditingButton.setOnClickListener(v -> {
-                if (listener != null) {
-                    listener.changeMode(NoteFragmentListener.Mode.DIRECT_EDIT, false);
-                }
-            });
-        } else {
-            getDirectEditingButton().setVisibility(View.GONE);
-            ExtendedFloatingActionButton edit = getNormalEditButton();
-            if(edit!=null) {
-                edit.setVisibility(View.VISIBLE);
-                edit.setOnClickListener(v -> {
-                    if (listener != null) {
-                        listener.changeMode(NoteFragmentListener.Mode.EDIT, true);
-                    }
-                });
-            }
-        }
-    }
-
-    private void checkDirectEditingAvailable() {
-        try {
-            final SingleSignOnAccount ssoAccount = SingleAccountHelper.getCurrentSingleSignOnAccount(requireContext());
-            final Account localAccount = repo.getAccountByName(ssoAccount.name);
-            directEditRemotelyAvailable = localAccount != null && localAccount.isDirectEditingAvailable();
-        } catch (NextcloudFilesAppAccountNotFoundException | NoCurrentAccountSelectedException e) {
-            Log.w(TAG, "checkDirectEditingAvailable: ", e);
-            directEditRemotelyAvailable = false;
-        }
-    }
-
-    protected boolean isDirectEditEnabled() {
-        if (!directEditRemotelyAvailable) {
-            return false;
-        }
-        final var sp = PreferenceManager.getDefaultSharedPreferences(requireContext().getApplicationContext());
-        return sp.getBoolean(getString(R.string.pref_key_enable_direct_edit), true);
     }
 
     @Override
@@ -163,11 +109,17 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                         colorWithText("", null, color);
                         searchQuery = "";
                         hideSearchFabs();
+                        if (listener != null) {
+                            listener.onSearchActive(false);
+                        }
                     } else {
                         jumpToOccurrence();
                         colorWithText(searchQuery, null, color);
                         occurrenceCount = countOccurrences(getContent(), searchQuery);
                         showSearchFabs();
+                        if (listener != null) {
+                            listener.onSearchActive(true);
+                        }
                     }
 
                     oldVisibility = currentVisibility;
@@ -278,13 +230,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
 
     protected abstract FloatingActionButton getSearchPrevButton();
 
-    @NonNull
-    protected abstract ExtendedFloatingActionButton getDirectEditingButton();
-
-    protected abstract ExtendedFloatingActionButton getNormalEditButton();
-
     private void showSearchFabs() {
-        ExtendedFabUtil.setExtendedFabVisibility(getDirectEditingButton(), false);
         final var next = getSearchNextButton();
         final var prev = getSearchPrevButton();
         if (prev != null) {
@@ -376,10 +322,5 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         final var util = BrandingUtil.of(color, requireContext());
         util.material.themeFAB(getSearchNextButton());
         util.material.themeFAB(getSearchPrevButton());
-        util.material.themeExtendedFAB(getDirectEditingButton());
-        var editFab = getNormalEditButton();
-        if(editFab != null) {
-            util.material.themeExtendedFAB(editFab);
-        }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
@@ -9,8 +9,8 @@ package it.niedermann.owncloud.notes.shared.util
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import com.google.android.material.R
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 object ExtendedFabUtil {
     @JvmStatic
@@ -28,7 +28,7 @@ object ExtendedFabUtil {
                     val animation =
                         AnimationUtils.loadAnimation(
                             extendedFab.context,
-                            R.anim.design_bottom_sheet_slide_out,
+                            com.google.android.material.R.anim.design_bottom_sheet_slide_out,
                         )
                     animation.setAnimationListener(
                         object : Animation.AnimationListener {
@@ -70,6 +70,20 @@ object ExtendedFabUtil {
             setExtendedFabVisibility(extendedFab, false)
         } else if (scrollY < oldScrollY && !extendedFab.isShown) {
             setExtendedFabVisibility(extendedFab, true)
+        }
+    }
+
+    @JvmStatic
+    fun toggleVisibilityOnScroll(
+        fab: FloatingActionButton,
+        scrollY: Int,
+        oldScrollY: Int,
+    ) {
+        @Suppress("ConvertTwoComparisonsToRangeCheck")
+        if (oldScrollY > 0 && scrollY > oldScrollY && fab.isShown) {
+            fab.hide()
+        } else if (scrollY < oldScrollY && !fab.isShown) {
+            fab.show()
         }
     }
 }

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -5,23 +5,66 @@
  ~ SPDX-FileCopyrightText: 2020-2024 Nextcloud GmbH and Nextcloud contributors
  ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <LinearLayout
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:navigationIcon="@drawable/ic_arrow_back_grey600_24dp"
+            tools:title="Edit Sample note" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_container_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_direct_edit"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:navigationIcon="@drawable/ic_arrow_back_grey600_24dp"
-        tools:title="Edit Sample note" />
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/noteMode_rich_edit"
+        android:src="@drawable/ic_rich_editing_grey600_24dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_edit"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:layout_marginBottom="88dp"
+        android:contentDescription="@string/simple_edit"
+        android:src="@drawable/ic_edit_grey600_24dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
-</LinearLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_preview"
+        style="?attr/floatingActionButtonPrimaryStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/spacer_2x"
+        android:contentDescription="@string/menu_preview"
+        android:src="@drawable/ic_eye_grey600_24dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_note_direct_edit.xml
+++ b/app/src/main/res/layout/fragment_note_direct_edit.xml
@@ -28,22 +28,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/plain_editing_fab"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/note_direct_edit_fab_margin_bottom"
-        android:layout_marginEnd="@dimen/spacer_2x"
-        android:contentDescription="@string/noteMode_plain_edit"
-        android:text="@string/noteMode_plain_edit"
-        android:visibility="gone"
-        app:backgroundTint="@color/defaultBrand"
-        app:icon="@drawable/ic_notes"
-        app:layout_anchor="@id/note_webview"
-        app:layout_anchorGravity="bottom|end"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:visibility="visible" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_note_edit.xml
+++ b/app/src/main/res/layout/fragment_note_edit.xml
@@ -69,19 +69,4 @@
         app:backgroundTint="@color/defaultBrand"
         app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
         tools:visibility="visible" />
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/direct_editing"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/noteMode_rich_edit"
-        android:text="@string/noteMode_rich_edit"
-        android:visibility="visible"
-        app:backgroundTint="@color/defaultBrand"
-        app:layout_anchor="@id/scrollView"
-        app:layout_anchorGravity="bottom|end"
-        app:icon="@drawable/ic_rich_editing" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_note_preview.xml
+++ b/app/src/main/res/layout/fragment_note_preview.xml
@@ -73,34 +73,4 @@
         app:backgroundTint="@color/defaultBrand"
         app:srcCompat="@drawable/ic_keyboard_arrow_down_white_24dp"
         tools:visibility="visible" />
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/direct_editing"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/noteMode_rich_edit"
-        android:text="@string/noteMode_rich_edit"
-        android:visibility="visible"
-        app:backgroundTint="@color/defaultBrand"
-        app:layout_anchor="@id/scrollView"
-        app:layout_anchorGravity="bottom|end"
-        app:icon="@drawable/ic_rich_editing" />
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/edit"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/spacer_2x"
-        android:contentDescription="@string/noteMode_plain_edit"
-        android:text="@string/noteMode_plain_edit"
-        android:visibility="visible"
-        app:backgroundTint="@color/defaultBrand"
-        app:icon="@drawable/ic_edit_grey600_24dp"
-        app:layout_anchor="@+id/direct_editing"
-        app:layout_anchorGravity="center" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -161,4 +161,5 @@
         <item name="iconGravity">textStart</item>
         <item name="iconPadding">0dp</item>
     </style>
+
 </resources>


### PR DESCRIPTION
This Pull Request reorganizes the action buttons (Edit, Direct Edit, and Preview) within the note editing flow. Previously, these buttons were managed individually within the fragments (NoteEditFragment, NotePreviewFragment, etc.). This change centralizes the button management into the EditNoteActivity.
Changes:

- Centralization: The buttons for editing, previewing, and rich-text editing are now part of the EditNoteActivity layout.
- Layout Upgrade: Updated activity_edit.xml to use a CoordinatorLayout for better control over Floating Action Button (FAB) behavior.
- Dynamic Visibility: Buttons are shown or hidden dynamically based on the current mode (Preview vs. Editor) and server capabilities (Direct Editing support).
- Scroll Behavior: FABs now respond to scroll events and hide/show accordingly using ExtendedFabUtil.
- Menu Cleanup: Removed redundant menu items from the toolbar, as these actions are now prominently handled by the FABs.
- - 
### 🖼️ Videos

🏚️ Before

https://github.com/user-attachments/assets/cb3aedd9-d529-4ab6-805c-2086c6a6afea

🏡 After

https://github.com/user-attachments/assets/d61dd370-3899-41a8-9ccb-8c5e46f39cc8

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
 
Disclosure: I am an external contributor, and this change was developed with the assistance of AI.
Assisted-by: Claude Code 2.1.80 (Claude Sonnet 3.7)