### PR TITLE
fix(widget): move single-note widget query off the main thread

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidget.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidget.kt
@@ -53,13 +53,15 @@ class SingleNoteWidget : AppWidgetProvider() {
     private fun updateAppWidget(context: Context, awm: AppWidgetManager, appWidgetIds: IntArray) {
         val repo = NotesRepository.getInstance(context)
         appWidgetIds.forEach { appWidgetId ->
-            repo.getSingleNoteWidgetData(appWidgetId)?.let { data ->
-                val pendingIntent = getPendingIntent(context, appWidgetId)
-                val serviceIntent = getServiceIntent(context, appWidgetId)
-                val views = getRemoteViews(context, pendingIntent, serviceIntent)
-                awm.run {
-                    updateAppWidget(appWidgetId, views)
-                    notifyAppWidgetViewDataChanged(appWidgetId, R.id.single_note_widget_lv)
+            executor.submit {
+                repo.getSingleNoteWidgetData(appWidgetId)?.let {
+                    val pendingIntent = getPendingIntent(context, appWidgetId)
+                    val serviceIntent = getServiceIntent(context, appWidgetId)
+                    val views = getRemoteViews(context, pendingIntent, serviceIntent)
+                    awm.run {
+                        updateAppWidget(appWidgetId, views)
+                        notifyAppWidgetViewDataChanged(appWidgetId, R.id.single_note_widget_lv)
+                    }
                 }
             }
         }


### PR DESCRIPTION
`SingleNoteWidget.updateAppWidget()` ran the blocking Room query `NotesRepository.getSingleNoteWidgetData()` synchronously inside the `onReceive()` / `onUpdate()` chain, i.e. on the main thread. This only works today because the Room database is built with `allowMainThreadQueries()` (`NotesDatabase.java`, already flagged with a `// FIXME`). A broadcast receiver doing disk I/O on the main thread risks jank or ANRs on slow storage.

**Fix:** the per-widget query and the subsequent `RemoteViews` update are now submitted to the provider's existing background executor — the same pattern `onDeleted()` already uses for `removeSingleNoteWidget()`. `AppWidgetManager` is safe to call from a background thread, so `updateAppWidget()` and `notifyAppWidgetViewDataChanged()` stay correct.

Fixes #2935

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was fully generated using Claude Code: claude-fable-5