### PR TITLE
fix(edit): keep editor toolbar below the status bar after activity recreation

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/EditNoteActivity.java
@@ -108,7 +108,7 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
 
         setSupportActionBar(binding.toolbar);
         binding.toolbar.setOnClickListener((v) -> fragment.showEditTitleDialog());
-        setImeInsets();
+        setWindowInsets();
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
@@ -120,7 +120,7 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
         });
     }
 
-    private void setImeInsets() {
+    private void setWindowInsets() {
         final var window = getWindow();
         if (window == null) {
             return;
@@ -128,22 +128,22 @@ public class EditNoteActivity extends LockedActivity implements BaseNoteFragment
 
         WindowCompat.setDecorFitsSystemWindows(window, false);
 
-        final var decorView = window.getDecorView();
-        ViewCompat.setOnApplyWindowInsetsListener(decorView, (v, insets) -> {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.getRoot(), (v, insets) -> {
+            Insets barInsets = insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
             Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
-            Insets navBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
 
             // Apply bottom padding when keyboard is shown
-            int bottomPadding = Math.max(imeInsets.bottom, navBarInsets.bottom);
+            int bottomPadding = Math.max(imeInsets.bottom, barInsets.bottom);
 
             v.setPadding(
-                    v.getPaddingLeft(),
-                    v.getPaddingTop(),
-                    v.getPaddingRight(),
+                    barInsets.left,
+                    barInsets.top,
+                    barInsets.right,
                     bottomPadding
             );
 
-            return insets;
+            return WindowInsetsCompat.CONSUMED;
         });
     }
 


### PR DESCRIPTION
Fixes a UI glitch in the note editor: the toolbar (and the in-note search bar) is sometimes drawn behind the status bar, overlapping the clock.

**Steps to reproduce (before this fix):** open a note, then switch the system between light and dark theme (or trigger any other configuration change that recreates the activity), or have the editor restored after such a change. On an Android 15 emulator: `adb shell cmd uimode night yes` while a note is open.

**Cause:** `EditNoteActivity` registered its window insets listener (introduced in #2701 to fix #2700) on the `DecorView`. A listener set there replaces `DecorView#onApplyWindowInsets` during insets dispatch, so the platform's own system bar fitting silently depends on decor-internal state - after a recreation the new `DecorView` never applies the status bar offset.

**Fix:** register the listener on the activity's own content view and apply the insets that actually arrive there. The platform's decor handling stays intact: if the platform already fits the system bars, the arriving insets are consumed and no extra padding is added; on a truly edge-to-edge window the content view pads itself (including display cutout). The bottom padding keeps the max(IME, system bars) logic from #2700, verified against the keyboard-overlap scenario.

**Testing:** manually verified on an Android 15 emulator (cold start light/dark, theme toggle recreation both directions, keyboard open/close, in-note search, landscape); `testFdroidDebugUnitTest` and `lintFdroidDebug` pass.

**Screenshots:** 
<img width="180" height="400" alt="before_broken_after_dark_mode_recreation" src="https://github.com/user-attachments/assets/f803cf93-3098-4523-9618-bdd05a96c126" /> <img width="180" height="400" alt="after_search_regression_check" src="https://github.com/user-attachments/assets/ab319682-b831-4491-8183-d75f82a0079f" /> <img width="180" height="400" alt="after_keyboard_regression_check" src="https://github.com/user-attachments/assets/ae8b3185-024a-4b52-9481-4c4427958fbf" /> <img width="180" height="400" alt="after_fixed_dark_mode_recreation" src="https://github.com/user-attachments/assets/03a4c4a5-f7e6-4ff3-b3f0-7ce77ab96399" />

_Disclosure: this change was developed with the assistance of an AI coding agent (Claude Code, Claude Fable 5, xhigh); I reviewed and tested the change myself._
