### PR TITLE
fix: reconcile direct-edit and plain-edit baselines to avoid false conflict dialog

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -370,8 +370,7 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
         val updateDisposable = Single.just(note.remoteId)
             .map { remoteId ->
                 val newNote = notesApi.getNote(remoteId).singleOrError().blockingGet().response
-                val localAccount = repo.getAccountByName(account.name)
-                repo.updateNoteAndSync(localAccount, note, newNote.content, newNote.title, null)
+                repo.updateNoteFromRemote(note.id, newNote)
             }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -455,6 +455,20 @@ public class NotesRepository {
         return db.getNoteDao().updateIfNotModifiedLocallyAndAnyRemoteColumnHasChanged(id, modified, title, favorite, category, eTag, content, excerpt);
     }
 
+    @WorkerThread
+    public int updateNoteFromRemote(long localNoteId, @NonNull Note remoteNote) {
+        final var modified = Objects.requireNonNull(remoteNote.getModified()).getTimeInMillis();
+        return updateIfNotModifiedLocallyAndAnyRemoteColumnHasChanged(
+                localNoteId,
+                modified,
+                remoteNote.getTitle(),
+                remoteNote.getFavorite(),
+                remoteNote.getCategory(),
+                remoteNote.getETag(),
+                remoteNote.getContent(),
+                generateNoteExcerpt(remoteNote.getContent(), remoteNote.getTitle()));
+    }
+
     public long countUnsynchronizedNotes(long accountId) {
         final Long unsynchronizedNotesCount = db.getNoteDao().countUnsynchronizedNotes(accountId);
         return unsynchronizedNotesCount == null ? 0 : unsynchronizedNotesCount;

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
@@ -206,6 +206,85 @@ public class NotesRepositoryTest {
     }
 
     @Test
+    public void updateNoteFromRemoteUpdatesSynchronizedNote() {
+        final var remoteModified = Calendar.getInstance();
+        final var remoteNote = new Note(
+                1001L,
+                remoteModified,
+                "Remote title",
+                "Remote title\nRemote content",
+                "Remote category",
+                true,
+                "remote-etag");
+
+        assertEquals(1, repo.updateNoteFromRemote(1, remoteNote));
+
+        final var storedNote = repo.getNoteById(1);
+        assertEquals("Remote title", storedNote.getTitle());
+        assertEquals("Remote title\nRemote content", storedNote.getContent());
+        assertEquals("Remote category", storedNote.getCategory());
+        assertTrue(storedNote.getFavorite());
+        assertEquals("remote-etag", storedNote.getETag());
+        assertEquals(remoteModified.getTimeInMillis(), storedNote.getModified().getTimeInMillis());
+        assertEquals("Remote content", storedNote.getExcerpt());
+        assertEquals(VOID, storedNote.getStatus());
+    }
+
+    @Test
+    public void updateNoteFromRemoteDoesNotOverwriteLocalEdits() {
+        final var localNote = repo.getNoteById(3);
+        final var remoteNote = new Note(
+                localNote.getRemoteId(),
+                Calendar.getInstance(),
+                "Remote title",
+                "Remote content",
+                "Remote category",
+                true,
+                "remote-etag");
+
+        assertEquals(0, repo.updateNoteFromRemote(localNote.getId(), remoteNote));
+
+        final var storedNote = repo.getNoteById(localNote.getId());
+        assertEquals(localNote.getTitle(), storedNote.getTitle());
+        assertEquals(localNote.getContent(), storedNote.getContent());
+        assertEquals(localNote.getCategory(), storedNote.getCategory());
+        assertEquals(localNote.getFavorite(), storedNote.getFavorite());
+        assertEquals(localNote.getETag(), storedNote.getETag());
+        assertEquals(localNote.getModified().getTimeInMillis(), storedNote.getModified().getTimeInMillis());
+        assertEquals(localNote.getExcerpt(), storedNote.getExcerpt());
+        assertEquals(LOCAL_EDITED, storedNote.getStatus());
+    }
+
+    @Test
+    public void updateNoteFromRemoteDoesNotDirtyIdenticalNoteOrScheduleSync() {
+        final var modified = Calendar.getInstance();
+        final var localNote = new Note(
+                1010L,
+                modified,
+                "Same title",
+                "Same content",
+                "Same category",
+                false,
+                "same-etag");
+        final var storedLocalNote = repo.addNote(account.getId(), localNote);
+        final var repoSpy = spy(repo);
+        final var identicalRemoteNote = new Note(
+                localNote.getRemoteId(),
+                modified,
+                localNote.getTitle(),
+                localNote.getContent(),
+                localNote.getCategory(),
+                localNote.getFavorite(),
+                localNote.getETag());
+
+        assertEquals(0, repoSpy.updateNoteFromRemote(storedLocalNote.getId(), identicalRemoteNote));
+
+        final var storedNote = repoSpy.getNoteById(storedLocalNote.getId());
+        assertEquals(VOID, storedNote.getStatus());
+        verify(repoSpy, times(0)).scheduleSync(any(), anyBoolean());
+    }
+
+    @Test
     public void updateApiVersion() {
         repo.updateApiVersion(account.getId(), "");
         assertNull(repo.getAccountById(account.getId()).getApiVersion());


### PR DESCRIPTION
Switching a note between plain edit and rich (direct) edit repeatedly no longer triggers the Text editor's "The document has been changed outside of the editor" conflict dialog when the user made no changes.

Reported in #2196 and confirmed by multiple reporters from app version 4.2.1 (2024) through a fresh reproduction on 2026-06-30. Switching modes two or more times reliably surfaced the conflict dialog ("Use current version" / "Use the saved version") even with no content change, because the plain editor and the server-side Text (direct edit) app each carried their own baseline and a mode switch made one look stale to the other. On opening a note, the two paths now reconcile against the same saved baseline before the editor loads, so an unmodified mode switch is not treated as an outside change; the dialog still fires for genuine outside edits.

Fixes #2196

### 🖼️ Screenshots

No UI change — this fixes an incorrect conflict dialog that appeared during plain/rich edit mode switches. The dialog itself is unchanged; it simply no longer fires on an unmodified note.

🏚️ Before | 🏡 After
---|---
Conflict dialog appears after toggling plain/rich edit on an unchanged note | No dialog on an unchanged note; genuine outside edits still raise it

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
