### PR TITLE
Fix alignment of note edit button to the bottom

### DIFF
--- a/app/src/main/res/layout/fragment_note_preview.xml
+++ b/app/src/main/res/layout/fragment_note_preview.xml
@@ -101,6 +101,6 @@
         android:visibility="visible"
         app:backgroundTint="@color/defaultBrand"
         app:icon="@drawable/ic_edit_grey600_24dp"
-        app:layout_anchor="@+id/direct_editing"
-        app:layout_anchorGravity="center" />
+        app:layout_anchor="@id/scrollView"
+        app:layout_anchorGravity="bottom|end" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Note: while the floating action button still overlaps with the text in the screenshot, there is sufficient padding beneath the note content, so the user can always scroll down far enough that the button and content do not collide.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1080" height="2280" alt="image" src="https://github.com/user-attachments/assets/27d30195-8e29-4f09-b099-820aa838200b" /> | <img width="1080" height="2280" alt="image" src="https://github.com/user-attachments/assets/34b97d59-bc1f-44c6-ae47-15591c4bbd25" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are ~~included or~~ not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
