### PR TITLE
fix: Tapping an item in list widget should open the tapped note

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/widget/notelist/NoteListWidget.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/widget/notelist/NoteListWidget.kt
@@ -19,7 +19,6 @@ import com.owncloud.android.lib.common.utils.Log_OC
 import it.niedermann.owncloud.notes.R
 import it.niedermann.owncloud.notes.edit.EditNoteActivity
 import it.niedermann.owncloud.notes.persistence.NotesRepository
-import it.niedermann.owncloud.notes.shared.util.WidgetUtil
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import androidx.core.net.toUri
@@ -97,8 +96,9 @@ class NoteListWidget : AppWidgetProvider() {
                         setPackage(context.packageName)
                     }
 
-                    val pendingIntentFlags =
-                        WidgetUtil.pendingIntentFlagCompat(PendingIntent.FLAG_UPDATE_CURRENT or Intent.FILL_IN_COMPONENT)
+                     val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or
+                         PendingIntent.FLAG_MUTABLE or
+                         Intent.FILL_IN_COMPONENT
                     val editNotePendingIntent =
                         PendingIntent.getActivity(context, 0, editNoteIntent, pendingIntentFlags)
 


### PR DESCRIPTION
Currently when tapping an item in the list widget, the app will open an empty note instead of the tapped note. This has been reported in multiple issues like:  #3168 [#2790 ](https://github.com/nextcloud/notes-android/issues/2790#issuecomment-3821721095)

The reason behind this is that the pending intent template is marked as immutable. This make it impossible for the system to fill in the data later. It will then open an empty note as the note id is passed to the editor as empty.

This PR added the mutable flag to the pending intent.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
