### PR TITLE
fix(main): create only one note when moving to another account

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
@@ -511,10 +511,9 @@ public class MainViewModel extends AndroidViewModel {
     }
 
     public LiveData<Note> moveNoteToAnotherAccount(Account account, long noteId) {
-        return switchMap(repo.getNoteById$(noteId), (note) -> {
-            Log.v(TAG, "[moveNoteToAnotherAccount] - note: " + (BuildConfig.DEBUG ? note : note.getTitle()));
-            return repo.moveNoteToAnotherAccount(account, note);
-        });
+        final var note = repo.getNoteById(noteId);
+        Log.v(TAG, "[moveNoteToAnotherAccount] - note: " + (note == null ? null : note.getTitle()));
+        return note == null ? new MutableLiveData<>() : repo.moveNoteToAnotherAccount(account, note);
     }
 
     public LiveData<Void> toggleFavoriteAndSync(Note note) {

--- a/app/src/test/java/it/niedermann/owncloud/notes/main/MainViewModelMoveNoteTest.kt
+++ b/app/src/test/java/it/niedermann/owncloud/notes/main/MainViewModelMoveNoteTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package it.niedermann.owncloud.notes.main
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import it.niedermann.owncloud.notes.persistence.NotesRepository
+import it.niedermann.owncloud.notes.persistence.entity.Account
+import it.niedermann.owncloud.notes.persistence.entity.Note
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class MainViewModelMoveNoteTest {
+
+    private lateinit var viewModel: MainViewModel
+    private lateinit var repo: NotesRepository
+
+    @Before
+    fun setUp() {
+        repo = mock(NotesRepository::class.java)
+        viewModel = MainViewModel(ApplicationProvider.getApplicationContext(), SavedStateHandle())
+        val field = MainViewModel::class.java.getDeclaredField(REPO_FIELD)
+        field.isAccessible = true
+        field.set(viewModel, repo)
+    }
+
+    @Test
+    fun moveNoteToAnotherAccount_readsNoteOnce() {
+        val account = mock(Account::class.java)
+        val note = Note()
+        val moved = MutableLiveData<Note>()
+        `when`(repo.getNoteById(NOTE_ID)).thenReturn(note)
+        `when`(repo.moveNoteToAnotherAccount(account, note)).thenReturn(moved)
+
+        val result = viewModel.moveNoteToAnotherAccount(account, NOTE_ID)
+
+        assertSame(moved, result)
+        verify(repo, times(1)).getNoteById(NOTE_ID)
+        verify(repo, times(1)).moveNoteToAnotherAccount(account, note)
+        verify(repo, never()).`getNoteById$`(anyLong())
+    }
+
+    @Test
+    fun moveNoteToAnotherAccount_skipsMoveWhenNoteMissing() {
+        val account = mock(Account::class.java)
+        `when`(repo.getNoteById(NOTE_ID)).thenReturn(null)
+
+        viewModel.moveNoteToAnotherAccount(account, NOTE_ID)
+
+        verify(repo, never()).moveNoteToAnotherAccount(any(), any())
+        verify(repo, never()).`getNoteById$`(anyLong())
+    }
+
+    companion object {
+        private const val NOTE_ID = 1L
+        private const val REPO_FIELD = "repo"
+    }
+}


### PR DESCRIPTION
I switched from an old Nextcloud installation to a new one.
On my phone I added both Nextcloud instances and tried to move Notes
from the old instance to the new one.

The "Move" function ("Verschieben") did the following:
- removed the note from the old Nextcloud instance
- created the same note multiple times on the new instance

I moved different notes. Sometimes it created the note 3 times, in other
cases about 20 times.

I used AI to help fix this bug. I built a debug version of the Notes app
and tested it. Moving a note now creates only one copy on the target
account.

The move ran again every time the local database updated the note, so
the app kept creating extra copies.

### 🖼️ Screenshots
not needed (behaviour bug)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
