### PR TITLE
Fixed loading message not disappearing when the note is loaded

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidget.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidget.kt
@@ -114,8 +114,6 @@ class SingleNoteWidget : AppWidgetProvider() {
         ).apply {
             setPendingIntentTemplate(R.id.single_note_widget_lv, pendingIntent)
             setRemoteAdapter(R.id.single_note_widget_lv, serviceIntent)
-            setViewVisibility(R.id.widget_single_note_placeholder_tv, View.VISIBLE)
-            setTextViewText(R.id.widget_single_note_placeholder_tv, context.getString(R.string.widget_single_note_loading))
         }
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/widget/singlenote/SingleNoteWidgetFactory.java
@@ -49,24 +49,33 @@ public class SingleNoteWidgetFactory implements RemoteViewsService.RemoteViewsFa
     @Override
     public void onDataSetChanged() {
         final var data = repo.getSingleNoteWidgetData(appWidgetId);
-        if (data != null) {
-            final long noteId = data.getNoteId();
-            Log.v(TAG, "Fetch note with id " + noteId);
-            note = repo.getNoteById(noteId);
-
-            final var views = new RemoteViews(context.getPackageName(), R.layout.widget_single_note);
-            if (note == null) {
-                Log.e(TAG, "Error: note not found");
-                views.setViewVisibility(R.id.widget_single_note_placeholder_tv, View.VISIBLE);
-                views.setTextViewText(R.id.widget_single_note_placeholder_tv,
-                        context.getString(R.string.widget_single_note_note_not_found));
-            } else {
-                views.setViewVisibility(R.id.widget_single_note_placeholder_tv, View.GONE);
-            }
-            AppWidgetManager.getInstance(context).partiallyUpdateAppWidget(appWidgetId, views);
-        } else {
-            Log.w(TAG, "Widget with ID " + appWidgetId + " seems to be not configured yet.");
+        final var views = new RemoteViews(context.getPackageName(), R.layout.widget_single_note);
+        if (data == null) {
+            showErrorView(context, views);
+            return;
         }
+
+        final long noteId = data.getNoteId();
+        note = repo.getNoteById(noteId);
+        Log.v(TAG, "Fetch note with id " + noteId);
+
+        if (note == null) {
+            showErrorView(context, views);
+            Log.e(TAG, "Error: note not found");
+            return;
+        }
+        views.setViewVisibility(R.id.widget_single_note_placeholder_tv, View.GONE);
+
+        AppWidgetManager.getInstance(context).partiallyUpdateAppWidget(appWidgetId, views);
+    }
+
+    private void showErrorView(Context context, RemoteViews views) {
+        views.setViewVisibility(R.id.single_note_widget_lv, View.GONE);
+        views.setViewVisibility(R.id.widget_single_note_placeholder_tv, View.VISIBLE);
+        views.setTextViewText(R.id.widget_single_note_placeholder_tv,
+                context.getString(R.string.widget_single_note_note_not_found));
+
+        AppWidgetManager.getInstance(context).partiallyUpdateAppWidget(appWidgetId, views);
     }
 
     @Override

--- a/app/src/main/res/layout/widget_single_note.xml
+++ b/app/src/main/res/layout/widget_single_note.xml
@@ -25,9 +25,8 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:padding="@dimen/spacer_1x"
-        android:text="@string/widget_single_note_note_not_found"
+        android:text="@string/widget_single_note_loading"
         android:textAlignment="center"
-        android:textColor="@color/widget_foreground"
-        android:visibility="gone" />
+        android:textColor="@color/widget_foreground" />
 
 </RelativeLayout>


### PR DESCRIPTION
Fix https://github.com/nextcloud/notes-android/issues/3318
Introduced in https://github.com/nextcloud/notes-android/commit/e5a4dab791e4e6f9840703df2cc6241df2a28714

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/07522872-cdc5-4b01-ab38-a4346f3eb8e6" /> | <img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/9bb48ae7-53a5-4a94-a41b-c6091ffeace0" />

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
