### PR TITLE
Avoid edit button to cover cursor when the text is scrolled due to the user deleting an entire line

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteDirectEditFragment.kt
@@ -109,6 +109,7 @@ class NoteDirectEditFragment : BaseNoteFragment(), Branded {
                             plainEditingFab,
                             scrollStart,
                             scrollEnd,
+                            false
                         )
                     }
                 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -58,6 +58,8 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     private Handler handler;
     private boolean saveActive;
     private boolean unsavedEdit;
+    private long lastTextChange = 0;
+
     private final Runnable runAutoSave = new Runnable() {
         @Override
         public void run() {
@@ -124,6 +126,11 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         return null;
     }
 
+    @Override
+    protected boolean userIsChangingText() {
+        return System.currentTimeMillis() - lastTextChange < USER_CHANGING_TEXT_TIMEOUT;
+    }
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
@@ -148,6 +155,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
 
             @Override
             public void afterTextChanged(final Editable s) {
+                lastTextChange = System.currentTimeMillis();
                 unsavedEdit = true;
                 if (!saveActive) {
                     handler.removeCallbacks(runAutoSave);

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -54,6 +54,8 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     @Nullable
     private Runnable setScrollY;
 
+    private long lastTextChange = 0;
+
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
@@ -102,6 +104,11 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
     }
 
     @Override
+    protected boolean userIsChangingText() {
+        return System.currentTimeMillis() - lastTextChange < USER_CHANGING_TEXT_TIMEOUT;
+    }
+
+    @Override
     protected Layout getLayout() {
         binding.singleNoteContent.onPreDraw();
         return binding.singleNoteContent.getLayout();
@@ -140,6 +147,7 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
 
         noteLoaded = true;
         registerInternalNoteLinkHandler();
+        registerInternalNoteTextChangedHandler();
 
         lifecycleScopeIOJob(() -> {
             final String content = note.getContent();
@@ -177,6 +185,10 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
             }
             return false;
         });
+    }
+
+    protected void registerInternalNoteTextChangedHandler() {
+        binding.singleNoteContent.setMarkdownStringChangedListener(charSequence -> lastTextChange = System.currentTimeMillis());
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -42,6 +42,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     private static final String TAG = SearchableBaseNoteFragment.class.getSimpleName();
     private static final String saved_instance_key_searchQuery = "searchQuery";
     private static final String saved_instance_key_currentOccurrence = "currentOccurrence";
+    protected static final long USER_CHANGING_TEXT_TIMEOUT = 200;
 
     private int currentOccurrence = 1;
     private int occurrenceCount = 0;
@@ -80,9 +81,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             final ExtendedFloatingActionButton directFab = getDirectEditingButton();
             final ExtendedFloatingActionButton normalFab = getNormalEditButton();
             if (directEditEnabled) {
-                ExtendedFabUtil.toggleVisibilityOnScroll(directFab, scrollY, oldScrollY);
+                ExtendedFabUtil.toggleVisibilityOnScroll(directFab, scrollY, oldScrollY, userIsChangingText());
             } else if (normalFab != null) {
-                ExtendedFabUtil.toggleVisibilityOnScroll(normalFab, scrollY, oldScrollY);
+                ExtendedFabUtil.toggleVisibilityOnScroll(normalFab, scrollY, oldScrollY, userIsChangingText());
             }
         }
     }
@@ -283,6 +284,8 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     protected abstract ExtendedFloatingActionButton getDirectEditingButton();
 
     protected abstract ExtendedFloatingActionButton getNormalEditButton();
+
+    protected abstract boolean userIsChangingText();
 
     private void showSearchFabs() {
         ExtendedFabUtil.setExtendedFabVisibility(getDirectEditingButton(), false);

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
@@ -24,7 +24,7 @@ object ExtendedFabUtil {
             if (extendedFab.isExtended) {
                 extendedFab.hide()
             } else {
-                if (extendedFab.animation == null) {
+                if (extendedFab.animation == null && extendedFab.isShown) {
                     val animation =
                         AnimationUtils.loadAnimation(
                             extendedFab.context,
@@ -64,9 +64,10 @@ object ExtendedFabUtil {
         extendedFab: ExtendedFloatingActionButton,
         scrollY: Int,
         oldScrollY: Int,
+        isTyping: Boolean
     ) {
         @Suppress("ConvertTwoComparisonsToRangeCheck")
-        if (oldScrollY > 0 && scrollY > oldScrollY && extendedFab.isShown) {
+        if (isTyping || (oldScrollY > 0 && scrollY > oldScrollY && extendedFab.isShown)) {
             setExtendedFabVisibility(extendedFab, false)
         } else if (scrollY < oldScrollY && !extendedFab.isShown) {
             setExtendedFabVisibility(extendedFab, true)

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/ExtendedFabUtil.kt
@@ -67,7 +67,8 @@ object ExtendedFabUtil {
         isTyping: Boolean
     ) {
         @Suppress("ConvertTwoComparisonsToRangeCheck")
-        if (isTyping || (oldScrollY > 0 && scrollY > oldScrollY && extendedFab.isShown)) {
+        val hasScrolledDown = oldScrollY > 0 && scrollY > oldScrollY && extendedFab.isShown
+        if (isTyping || hasScrolledDown) {
             setExtendedFabVisibility(extendedFab, false)
         } else if (scrollY < oldScrollY && !extendedFab.isShown) {
             setExtendedFabVisibility(extendedFab, true)


### PR DESCRIPTION
Fix: https://github.com/nextcloud/notes-android/issues/2272#issuecomment-5453573178

How to repro:
- Write a long text so that the view will scroll
- Delete a line so it scrolls back due to the shorter text
- The FAB covers the text and makes impossible to see what is being written/deleted

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
[before.webm](https://github.com/user-attachments/assets/2648fe37-c2d9-44e0-b287-3f6e91b7c062) | [after.webm](https://github.com/user-attachments/assets/24715596-8971-451e-8950-524238364c2a)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
